### PR TITLE
No need to fake an email

### DIFF
--- a/preload/1-government-hsts.rb
+++ b/preload/1-government-hsts.rb
@@ -1,12 +1,12 @@
 #!/usr/bin/env ruby
 
 # Script by Eric Mill to detect government domains in the Chrome HSTS Preload list.
-# 
+#
 # The Chrome HSTS Preload list is a hardcoded set of domains for which the browser
 # will *only* ever access the site using HTTPS. If an http:// link to that site is
 # encountered, the browser will just rewrite the URL to https:// before following
 # it.
-# 
+#
 # This list is also incorporated into Firefox and Safari, making it a nice list to
 # be on.
 #
@@ -15,10 +15,10 @@
 # domain must use the HSTS header, with the `includeSubdomains` flag included.
 #
 # Third- or fourth-level domains (e.g. 18f.gsa.gov, eric.mill.usesthis.com) must
-# be emailed to the Chrome team directly, and added manually. 
+# be emailed to the Chrome team directly, and added manually.
 #
-# In October 2014, 18F submitted 18f.gsa.gov and my.usa.gov to the Chrome HSTS 
-# Preload list, making them the first US government domains in the list. There are 
+# In October 2014, 18F submitted 18f.gsa.gov and my.usa.gov to the Chrome HSTS
+# Preload list, making them the first US government domains in the list. There are
 # 3 domains from other governments: 1 from the UK, and 2 from Australia.
 
 # Super-fast JSON parser.
@@ -38,8 +38,8 @@ hsts_domains = entries.
   # get a list of just the domain names
   map {|e| e['name']}
 
-# Match each domain against Gman using a fake 18f@ email address.
-matches = hsts_domains.select {|h| Gman.valid?("18f@#{h}")}
+# Match each domain against Gman
+matches = hsts_domains.select {|h| Gman.valid?(h) }
 
 # As of 2014-11-09:
 #


### PR DESCRIPTION
Gman will parse [any domain-like string](https://github.com/benbalter/naughty_or_nice/blob/master/lib/naughty_or_nice.rb#L55-L82), including `https://18f.gsa.gov`, `18f.gsa.gov`, `https://18f.gsa.gov/foo`, and `foo@18f.gsa.gov`.
