### PR TITLE
Make output directory configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Run multiple scanners on each domain:
 
 * `--scan` - **Required.** Comma-separated names of one or more scanners.
 * `--debug` - Print out more stuff.
+* `--output` - Where to output results data. Defaults to `./results/`.
 * `--force` - Ignore cached data and force scans to hit the network.
 * `--analytics` - Required if using the `analytics` scanner. Point this to the CSV of participating domains.
 
@@ -59,9 +60,11 @@ Full scan data about each domain is saved in the `cache/` directory, named after
 
 * Example: `cache/inspect/whitehouse.gov.json`
 
-Highlights from the scan data about all domains are saved in the `results/` directory, named after each scan, in CSV.
+Highlights from the scan data about all domains are saved in the output directory (which defaults to `./results/`) in CSV form, named after each scan.
 
 * Example: `results/inspect.csv`
+
+You can override the output directory by specifying `--output`.
 
 It's possible for scans to save multiple CSV rows per-domain. For example, the `tls` scan may have a row with details for each detected TLS "endpoint".
 
@@ -78,8 +81,6 @@ Then to scan, prefix commands with `docker-compose run`, like:
 ```bash
 docker-compose run scan <domain> --scan=<scanner>
 ```
-
-The results will be in the `results` folder.
 
 ### TODOs
 

--- a/scan
+++ b/scan
@@ -10,9 +10,10 @@ import csv
 
 # basic setup - logs, output dirs
 options = utils.options()
+results_dir = options.get("output", "results")
 utils.configure_logging(options)
-utils.mkdir_p("cache")
-utils.mkdir_p("results")
+utils.mkdir_p(utils.cache_dir())
+utils.mkdir_p(results_dir)
 
 
 ###
@@ -64,14 +65,14 @@ def run(options=None):
 def scan_domains(scanners, domains):
 
     # Clear out existing result CSVs, to avoid inconsistent data.
-    for result in glob.glob("results/*.csv"):
+    for result in glob.glob("%s/*.csv" % results_dir):
         os.remove(result)
 
     # Run through each scanner and open a file and CSV for each.
     handles = {}
     for scanner in scanners:
         name = scanner.__name__.split(".")[-1]  # e.g. 'inspect'
-        scanner_file = open("results/%s.csv" % name, 'w', newline='')
+        scanner_file = open("%s/%s.csv" % (results_dir, name), 'w', newline='')
         scanner_writer = csv.writer(scanner_file)
         scanner_writer.writerow(["Domain"] + scanner.headers)
 

--- a/scanners/utils.py
+++ b/scanners/utils.py
@@ -98,9 +98,8 @@ def write(content, destination, binary=False):
     f.close()
 
 
-def data_dir():
+def cache_dir():
     return "cache"
-
 
 def notify(body):
     try:
@@ -143,7 +142,7 @@ def scan(command):
 
 # Predictable cache path for a domain and operation.
 def cache_path(domain, operation):
-    return os.path.join(data_dir(), operation, ("%s.json" % domain))
+    return os.path.join(cache_dir(), operation, ("%s.json" % domain))
 
 
 # Used to quickly get cached data for a domain.


### PR DESCRIPTION
Make it so that output can go somewhere besides `./results/`, given an `--output` directory. The specified directory will be created if it doesn't already exist.