### PR TITLE
Output metadata with each report

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 ipython
+strict-rfc3339

--- a/scan
+++ b/scan
@@ -1,8 +1,10 @@
 #!/usr/bin/env python3
 
 import os
+import sys
 import glob
 from scanners import utils
+import datetime
 import logging
 import importlib
 import csv
@@ -15,6 +17,9 @@ utils.configure_logging(options)
 utils.mkdir_p(utils.cache_dir())
 utils.mkdir_p(results_dir)
 
+# some metadata about the scan itself
+start_time = utils.utc_timestamp()
+start_command = str.join(" ", sys.argv)
 
 ###
 # Entry point. `options` is a dict of CLI flags.
@@ -94,6 +99,14 @@ def scan_domains(scanners, domains):
         handles[scanner]['file'].close()
 
     logging.warn("Results written to CSV.")
+
+    # Save metadata.
+    metadata = {
+        'start_time': start_time,
+        'end_time': utils.utc_timestamp(),
+        'command': start_command
+    }
+    utils.write(utils.json_for(metadata), "%s/meta.json" % results_dir)
 
 
 # Yield domain names from a single string, or a CSV of them.

--- a/scanners/utils.py
+++ b/scanners/utils.py
@@ -7,7 +7,7 @@ import json
 import csv
 import logging
 import datetime
-
+import strict_rfc3339
 
 # Wrapper to a run() method to catch exceptions.
 def run(run_method, additional=None):
@@ -162,6 +162,9 @@ def invalid(data=None):
     data['invalid'] = True
     return json_for(data)
 
+# RFC 3339 timestamp for the current time when called
+def utc_timestamp():
+    return strict_rfc3339.now_to_rfc3339_utcoffset()
 
 # Load the first column of a CSV into memory as an array of strings.
 def load_domains(domain_csv):


### PR DESCRIPTION
This adds a `meta.json` file to the root of the output directory for a scan.

An example `meta.json` might look like:

```json
{
  "command": "./scan konklone.com --debug --scan=inspect",
  "end_time": "2015-06-07T19:53:19Z",
  "start_time": "2015-06-07T19:53:19Z"
}
```