### PR TITLE
Add a --suffix option to allow a common domain root

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Run multiple scanners on each domain:
 * `--debug` - Print out more stuff.
 * `--output` - Where to output results data. Defaults to `./results/`.
 * `--force` - Ignore cached data and force scans to hit the network.
+* `--suffix` - Add a suffix to all input domains. For example, a `--suffix` of `virginia.gov` will add `.virginia.gov` to the end of all input domains.
 * `--analytics` - Required if using the `analytics` scanner. Point this to the CSV of participating domains.
 
 ### Output

--- a/scan
+++ b/scan
@@ -13,6 +13,7 @@ import csv
 # basic setup - logs, output dirs
 options = utils.options()
 results_dir = options.get("output", "results")
+domain_suffix = options.get("suffix")
 utils.configure_logging(options)
 utils.mkdir_p(utils.cache_dir())
 utils.mkdir_p(results_dir)
@@ -116,7 +117,11 @@ def domains_from(arg):
             for row in csv.reader(csvfile):
                 if (not row[0]) or (row[0].lower().startswith("domain")):
                     continue
-                yield row[0].lower()
+                domain = row[0].lower()
+                if domain_suffix:
+                    yield "%s.%s" % (domain, domain_suffix)
+                else:
+                    yield domain
     else:
         yield arg
 


### PR DESCRIPTION
Lets you apply a suffix domain, which allows inputs to be bare subdomains, rather than fully qualified domain names.

For example, passing `--suffix=virginia.gov` allows you to take the list of [Virginia subdomains](http://data.openva.com/en/dataset/virginia-gov-subdomains) and automatically have domain-scan apply `.virginia.gov` to the end of all input domain columns