### PR TITLE
Make --output apply to both cache/ and results/ directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,18 +50,20 @@ Run multiple scanners on each domain:
 
 * `--scan` - **Required.** Comma-separated names of one or more scanners.
 * `--debug` - Print out more stuff.
-* `--output` - Where to output results data. Defaults to `./results/`.
+* `--output` - Where to output the `cache/` and `results/` directories. Defaults to `./`.
 * `--force` - Ignore cached data and force scans to hit the network.
 * `--suffix` - Add a suffix to all input domains. For example, a `--suffix` of `virginia.gov` will add `.virginia.gov` to the end of all input domains.
 * `--analytics` - Required if using the `analytics` scanner. Point this to the CSV of participating domains.
 
 ### Output
 
+All output files are placed into `cache/` and `results/` directories, whose location defaults to the current directory (`./`). Override the output home with `--output`.
+
 * **Cached full scan data** about each domain is saved in the `cache/` directory, named after each scan and each domain, in JSON.
 
 Example: `cache/inspect/whitehouse.gov.json`
 
-* **Formal output data** in CSV form about all domains are saved in the output directory (which defaults to `./results/`) in CSV form, named after each scan.
+* **Formal output data** in CSV form about all domains are saved in the `results/` directory in CSV form, named after each scan.
 
 Example: `results/inspect.csv`
 
@@ -69,7 +71,7 @@ You can override the output directory by specifying `--output`.
 
 It's possible for scans to save multiple CSV rows per-domain. For example, the `tls` scan may have a row with details for each detected TLS "endpoint".
 
-* **Scan metadata** with the start time, end time, and scan command will be placed in the output directory as `meta.json`.
+* **Scan metadata** with the start time, end time, and scan command will be placed in the `results/` directory as `meta.json`.
 
 Example: `results/meta.json`
 

--- a/scan
+++ b/scan
@@ -12,11 +12,10 @@ import csv
 
 # basic setup - logs, output dirs
 options = utils.options()
-results_dir = options.get("output", "results")
 domain_suffix = options.get("suffix")
 utils.configure_logging(options)
 utils.mkdir_p(utils.cache_dir())
-utils.mkdir_p(results_dir)
+utils.mkdir_p(utils.results_dir())
 
 # some metadata about the scan itself
 start_time = utils.utc_timestamp()
@@ -71,14 +70,14 @@ def run(options=None):
 def scan_domains(scanners, domains):
 
     # Clear out existing result CSVs, to avoid inconsistent data.
-    for result in glob.glob("%s/*.csv" % results_dir):
+    for result in glob.glob("%s/*.csv" % utils.results_dir()):
         os.remove(result)
 
     # Run through each scanner and open a file and CSV for each.
     handles = {}
     for scanner in scanners:
         name = scanner.__name__.split(".")[-1]  # e.g. 'inspect'
-        scanner_file = open("%s/%s.csv" % (results_dir, name), 'w', newline='')
+        scanner_file = open("%s/%s.csv" % (utils.results_dir(), name), 'w', newline='')
         scanner_writer = csv.writer(scanner_file)
         scanner_writer.writerow(["Domain"] + scanner.headers)
 
@@ -107,7 +106,7 @@ def scan_domains(scanners, domains):
         'end_time': utils.utc_timestamp(),
         'command': start_command
     }
-    utils.write(utils.json_for(metadata), "%s/meta.json" % results_dir)
+    utils.write(utils.json_for(metadata), "%s/meta.json" % utils.results_dir())
 
 
 # Yield domain names from a single string, or a CSV of them.

--- a/scanners/utils.py
+++ b/scanners/utils.py
@@ -97,9 +97,14 @@ def write(content, destination, binary=False):
     f.write(content)
     f.close()
 
+def report_dir():
+    return options().get("output", "./")
 
 def cache_dir():
-    return "cache"
+    return os.path.join(report_dir(), "cache")
+
+def results_dir():
+    return os.path.join(report_dir(), "results")
 
 def notify(body):
     try:


### PR DESCRIPTION
Move the entirety of a report's output, both `cache/` and `results/`, to the given output directory. So now `cache/` and `results/` are not configurable, but their location is.

This prevents reports' caches from interfering with each other, and makes it easy to blow away the cache on a per-report basis. If you want two reports to share a cache, do it with manual intervention: symlinks, or copying the cache directory from one place to another, whatever.