### PR TITLE
Parallelize domain scanning by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,9 @@ Run multiple scanners on each domain:
 
 It's important to understand that **scans run in parallel by default**, and so **the order of result data is unpredictable**.
 
-By default, each scanner will run up to 100 parallel tasks. Some scanners may limit this. For example, the `tls` scanner, which hits the SSL Labs API, maxes out at 5 tasks at once.
+By default, each scanner will run up to 10 parallel tasks, which you can override with `--workers`.
+
+Some scanners may limit this. For example, the `tls` scanner, which hits the SSL Labs API, maxes out at 5 tasks at once (which cannot be overridden with `--workers`).
 
 To disable this and run sequentially through each domain (1 worker), use `--serial`.
 
@@ -61,6 +63,7 @@ To disable this and run sequentially through each domain (1 worker), use `--seri
 * `--scan` - **Required.** Comma-separated names of one or more scanners.
 * `--serial` - Disable parallelization, force each task to be done simultaneously. Helpful for testing and debugging.
 * `--debug` - Print out more stuff. Useful with `--serial`.
+* `--workers` - Limit parallel threads per-scanner to a number.
 * `--output` - Where to output the `cache/` and `results/` directories. Defaults to `./`.
 * `--force` - Ignore cached data and force scans to hit the network.
 * `--suffix` - Add a suffix to all input domains. For example, a `--suffix` of `virginia.gov` will add `.virginia.gov` to the end of all input domains.

--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ Run multiple scanners on each domain:
 ./scan whitehouse.gov --scan=inspect,tls
 ```
 
+It's important to understand that **scans run in parallel by default**, and so **the order of result data is unpredictable**. To disable this and run sequentially through each domain, use `--serial`.
+
 **Scanners:**
 
 * `inspect` - HTTP/HTTPS/HSTS configuration.
@@ -49,7 +51,8 @@ Run multiple scanners on each domain:
 **Options:**
 
 * `--scan` - **Required.** Comma-separated names of one or more scanners.
-* `--debug` - Print out more stuff.
+* `--serial` - Disable parallelization, force each task to be done simultaneously. Helpful for testing and debugging.
+* `--debug` - Print out more stuff. Useful with `--serial`.
 * `--output` - Where to output the `cache/` and `results/` directories. Defaults to `./`.
 * `--force` - Ignore cached data and force scans to hit the network.
 * `--suffix` - Add a suffix to all input domains. For example, a `--suffix` of `virginia.gov` will add `.virginia.gov` to the end of all input domains.

--- a/README.md
+++ b/README.md
@@ -40,7 +40,15 @@ Run multiple scanners on each domain:
 ./scan whitehouse.gov --scan=inspect,tls
 ```
 
-It's important to understand that **scans run in parallel by default**, and so **the order of result data is unpredictable**. To disable this and run sequentially through each domain, use `--serial`.
+##### Parallelization
+
+It's important to understand that **scans run in parallel by default**, and so **the order of result data is unpredictable**.
+
+By default, each scanner will run up to 100 parallel tasks. Some scanners may limit this. For example, the `tls` scanner, which hits the SSL Labs API, maxes out at 5 tasks at once.
+
+To disable this and run sequentially through each domain (1 worker), use `--serial`.
+
+##### Options
 
 **Scanners:**
 

--- a/scan
+++ b/scan
@@ -105,7 +105,7 @@ def scan_domains(scanners, domains):
         elif hasattr(scanner, "workers"):
             workers = scanner.workers
         else:
-            workers = 100
+            workers = int(options.get("workers", 10))
 
         with ThreadPoolExecutor(max_workers=workers) as executor:
             tasks = ((scanner, domain, options) for domain in domains_from(domains))

--- a/scan
+++ b/scan
@@ -86,8 +86,7 @@ def scan_domains(scanners, domains):
             'writer': scanner_writer
         }
 
-    # Used to make a convenience wrapper for executor.map.
-    # params is (domain, options)
+    # The task wrapper that's parallelized using executor.map.
     def process_scan(params):
         scanner, domain, options = params
         # A scanner can return multiple rows.
@@ -97,10 +96,18 @@ def scan_domains(scanners, domains):
                 handles[scanner]['writer'].writerow([domain] + row)
 
 
-    # For each scanner, run through each domain.
-    # Use a unique process pool per-scanner.
+    # Run each scanner (unique process pool) over each domain.
+    # User can force --serial, and scanners can override default of 100.
     for scanner in scanners:
-        with ThreadPoolExecutor(max_workers=100) as executor:
+
+        if options.get("serial"):
+            workers = 1
+        elif hasattr(scanner, "workers"):
+            workers = scanner.workers
+        else:
+            workers = 100
+
+        with ThreadPoolExecutor(max_workers=workers) as executor:
             tasks = ((scanner, domain, options) for domain in domains_from(domains))
             executor.map(process_scan, tasks)
 

--- a/scan
+++ b/scan
@@ -8,7 +8,7 @@ import datetime
 import logging
 import importlib
 import csv
-
+from concurrent.futures import ThreadPoolExecutor
 
 # basic setup - logs, output dirs
 options = utils.options()
@@ -86,13 +86,23 @@ def scan_domains(scanners, domains):
             'writer': scanner_writer
         }
 
-    # For each domain, run through each scanner.
-    for domain in domains_from(domains):
-        for scanner in scanners:
-            # A scanner can return multiple rows.
-            for row in scanner.scan(domain, options):
-                if row:
-                    handles[scanner]['writer'].writerow([domain] + row)
+    # Used to make a convenience wrapper for executor.map.
+    # params is (domain, options)
+    def process_scan(params):
+        scanner, domain, options = params
+        # A scanner can return multiple rows.
+
+        for row in scanner.scan(domain, options):
+            if row:
+                handles[scanner]['writer'].writerow([domain] + row)
+
+
+    # For each scanner, run through each domain.
+    # Use a unique process pool per-scanner.
+    for scanner in scanners:
+        with ThreadPoolExecutor(max_workers=100) as executor:
+            tasks = ((scanner, domain, options) for domain in domains_from(domains))
+            executor.map(process_scan, tasks)
 
     # Close up all the files.
     for scanner in scanners:

--- a/scanners/analytics.py
+++ b/scanners/analytics.py
@@ -12,7 +12,6 @@ import os
 command = None
 analytics_domains = None
 
-
 def init(options):
     global analytics_domains
 

--- a/scanners/inspect.py
+++ b/scanners/inspect.py
@@ -14,7 +14,6 @@ import os
 command = os.environ.get("SITE_INSPECTOR_PATH", "site-inspector")
 init = None
 
-
 def scan(domain, options):
     logging.debug("[%s][inspect]" % domain)
 

--- a/scanners/tls.py
+++ b/scanners/tls.py
@@ -16,7 +16,7 @@ import os
 
 command = os.environ.get("SSLLABS_PATH", "ssllabs-scan")
 init = None
-
+workers = 5
 
 def scan(domain, options):
     logging.debug("[%s][tls]" % domain)


### PR DESCRIPTION
![doing good](https://cloud.githubusercontent.com/assets/4592/8146749/93217cb8-1218-11e5-8233-078c87f6af5e.png)

This parallelizes domain scanning by default. It flips the loop so that we first go through each requested scan type, and blast scans of that type in parallel over the given set of domains. Each scanner type will finish its parallelized worker pool before proceeding to the next scanner type.

After a bit of testing, I'm using 10 workers per-scanner as a default, overrideable with `--workers`. The `tls` scanner, which hits SSL Labs, forces it to 5 workers, with no override available besides editing the code. A `--serial` option overrides everything and locks the scanners each to 1 worker.

I find it doable on my machine to run 100 workers per-scanner, which is what the above uses, but I then also find that it's difficult to do other tasks on the computer while that's happening!

Fixes #16. cc @ramirezg @jtexnl