### PR TITLE
open domain.csv as utf-8

### DIFF
--- a/scan
+++ b/scan
@@ -112,7 +112,7 @@ def scan_domains(scanners, domains):
 # Yield domain names from a single string, or a CSV of them.
 def domains_from(arg):
     if arg.endswith(".csv"):
-        with open(arg, newline='') as csvfile:
+        with open(arg, encoding='utf-8', newline='') as csvfile:
             for row in csv.reader(csvfile):
                 if (not row[0]) or (row[0].lower().startswith("domain")):
                     continue


### PR DESCRIPTION
I had some problems opening domain.csv files that where stored as UTF-8. Not sure if it was a problem of the docker container or a general thing. I added the encoding explicitly. If this breaks any existing domain.csv I can a some detection logic for the encoding to avoid this.