### PR TITLE
Add --sort option to sort result CSVs alphabetically

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ To disable this and run sequentially through each domain (1 worker), use `--seri
 **Options:**
 
 * `--scan` - **Required.** Comma-separated names of one or more scanners.
+* `--sort` - Sort result CSVs by domain name, alphabetically. (**Note:** this causes the entire dataset to be read into memory.)
 * `--serial` - Disable parallelization, force each task to be done simultaneously. Helpful for testing and debugging.
 * `--debug` - Print out more stuff. Useful with `--serial`.
 * `--workers` - Limit parallel threads per-scanner to a number.

--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ Some scanners may limit this. For example, the `tls` scanner, which hits the SSL
 
 To disable this and run sequentially through each domain (1 worker), use `--serial`.
 
+Parallelization will also cause the resulting domains to be written in an unpredictable order. If the row order is important to you, disable parallelization, or use the `--sort` parameter to sort the resulting CSVs once the scans have completed. (**Note:** Using `--sort` will cause the entire dataset to be read into memory.)
+
 ##### Options
 
 **Scanners:**

--- a/scan
+++ b/scan
@@ -7,6 +7,7 @@ from scanners import utils
 import datetime
 import logging
 import importlib
+import shutil
 import csv
 from concurrent.futures import ThreadPoolExecutor
 
@@ -77,12 +78,14 @@ def scan_domains(scanners, domains):
     handles = {}
     for scanner in scanners:
         name = scanner.__name__.split(".")[-1]  # e.g. 'inspect'
-        scanner_file = open("%s/%s.csv" % (utils.results_dir(), name), 'w', newline='')
+        scanner_filename = "%s/%s.csv" % (utils.results_dir(), name)
+        scanner_file = open(scanner_filename, 'w', newline='')
         scanner_writer = csv.writer(scanner_file)
         scanner_writer.writerow(["Domain"] + scanner.headers)
 
         handles[scanner] = {
             'file': scanner_file,
+            'filename': scanner_filename,
             'writer': scanner_writer
         }
 
@@ -111,9 +114,11 @@ def scan_domains(scanners, domains):
             tasks = ((scanner, domain, options) for domain in domains_from(domains))
             executor.map(process_scan, tasks)
 
-    # Close up all the files.
+    # Close up all the files, --sort if requested (expensive).
     for scanner in scanners:
         handles[scanner]['file'].close()
+        if options.get("sort"):
+            sort_csv(handles[scanner]['filename'])
 
     logging.warn("Results written to CSV.")
 
@@ -124,6 +129,7 @@ def scan_domains(scanners, domains):
         'command': start_command
     }
     utils.write(utils.json_for(metadata), "%s/meta.json" % utils.results_dir())
+
 
 
 # Yield domain names from a single string, or a CSV of them.
@@ -140,6 +146,50 @@ def domains_from(arg):
                     yield domain
     else:
         yield arg
+
+# Sort a CSV by domain name, "in-place" (by making a temporary copy).
+# This loads the whole thing into memory: it's not a great solution for
+# super-large lists of domains.
+def sort_csv(input_filename):
+    logging.warn("Sorting %s..." % input_filename)
+
+    input_file = open(input_filename, encoding='utf-8', newline='')
+    tmp_filename = "%s.tmp" % input_filename
+    tmp_file = open(tmp_filename, 'w', newline='')
+    tmp_writer = csv.writer(tmp_file)
+
+    # store list of domains, to sort at the end
+    domains = []
+
+    # index rows by domain
+    rows = {}
+    header = None
+
+    for row in csv.reader(input_file):
+        # keep the header around
+        if (row[0].lower().startswith("domain")):
+            header = row
+            continue
+
+        # index domain for later reference
+        domain = row[0]
+        domains.append(domain)
+        rows[domain] = row
+
+    # straight alphabet sort
+    domains.sort()
+
+    # write out to a new file
+    tmp_writer.writerow(header)
+    for domain in domains:
+        tmp_writer.writerow(rows[domain])
+
+    # close the file handles
+    input_file.close()
+    tmp_file.close()
+
+    # replace the original
+    shutil.move(tmp_filename, input_filename)
 
 if __name__ == '__main__':
     run(options)


### PR DESCRIPTION
This adds a `--sort` flag that causes result CSVs to be sorted alphabetically by domain name.

It does this by waiting until all scanning is done and all tasks have completed, and then reading in each CSV, in turn, sorting the domain names, and writing the rows back out to a temporary file in alphabetical order. The temporary file is then moved back to overwrite the original CSV. The header row is preserved.

**Using `--sort` reads the entire dataset into memory,** so may be inappropriate for huge datasets. However, it works instantaneously for me with a ~1350-domain set.

Fixes #27.