### PR TITLE
Allow --analytics to be a URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Parallelization will also cause the resulting domains to be written in an unpred
 * `--output` - Where to output the `cache/` and `results/` directories. Defaults to `./`.
 * `--force` - Ignore cached data and force scans to hit the network. For the `tls` scanner, this also tells SSL Labs to ignore its server-side cache.
 * `--suffix` - Add a suffix to all input domains. For example, a `--suffix` of `virginia.gov` will add `.virginia.gov` to the end of all input domains.
-* `--analytics` - Required if using the `analytics` scanner. Point this to the CSV of participating domains.
+* `--analytics` - Required if using the `analytics` scanner. Point this to either a file **or** a URL that contains a CSV of participating domains.
 
 ### Output
 

--- a/scanners/analytics.py
+++ b/scanners/analytics.py
@@ -2,6 +2,7 @@
 from scanners import utils
 import logging
 import os
+import requests
 
 ###
 # == analytics ==
@@ -16,14 +17,34 @@ def init(options):
     global analytics_domains
 
     analytics_file = options.get("analytics")
-    if ((not analytics_file) or
-            (not analytics_file.endswith(".csv")) or
-            (not os.path.exists(analytics_file))):
-        no_csv = "--analytics should point to a CSV of participating domains."
+    if (not analytics_file) or (not analytics_file.endswith(".csv")):
+        no_csv = "--analytics should point to the file path or URL to a CSV of participating domains."
         logging.error(no_csv)
         return False
 
-    analytics_domains = utils.load_domains(analytics_file)
+    # It's a URL, download it first.
+    if analytics_file.startswith("http:") or analytics_file.startswith("https:"):
+
+        analytics_path = os.path.join(utils.cache_dir(), "analytics.csv")
+
+        try:
+            response = requests.get(analytics_file)
+            utils.write(response.text, analytics_path)
+        except:
+            no_csv = "--analytics URL not downloaded successfully."
+            logging.error(no_csv)
+            return False
+
+    # Otherwise, read it off the disk
+    else:
+        analytics_path = analytics_file
+
+        if (not os.path.exists(analytics_path)):
+            no_csv = "--analytics file not found."
+            logging.error(no_csv)
+            return False
+
+    analytics_domains = utils.load_domains(analytics_path)
 
     return True
 


### PR DESCRIPTION
This extends the `analytics` scanner so that the `--analytics` argument can point to either a local file _or_ an HTTP/HTTPS URL. It uses `requests`, which performs any necessary gzip decompression automatically. I've tested this out with [the Digital Analytics Program's participation CSV URL](https://analytics.usa.gov/data/live/second-level-domains.csv) and it works just fine.