### PR TITLE
JSON comment detector for HSTS preload list parser was too broad

### DIFF
--- a/scanners/inspect.py
+++ b/scanners/inspect.py
@@ -34,9 +34,9 @@ def get_chrome_preload_list():
 
     # The .json file contains '//' comments, which are not actually valid JSON,
     # and confuse Python's JSON decoder. Begone, foul comments!
-    raw = ''.join([ re.sub(r'//.*$', '', line)
+    raw = ''.join([ re.sub(r'^\s*//.*$', '', line)
                     for line in raw.splitlines() ])
-
+    
     preload_list_json = json.loads(raw)
     return { entry['name'] for entry in preload_list_json['entries'] }
 


### PR DESCRIPTION
In a [recent HSTS preload list update](https://chromium.googlesource.com/chromium/src/+/db949c345a8c561f45a2351daa06dc9c85671e88), Google added a `report_uri` field for its pins that contained a URL:

```json
"report_uri": "http://clients3.google.com/cert_upload_json"
```

The `//` in the URL broke the regex that stripped the Chrome preload list of comments before using Python's JSON parser. I've updated the regex to require the `//` to have occurred at the start of the line (allowing optional prefixed whitespace), which seems to have fixed the issue.

cc @garrettr 