### PR TITLE
Accessibility scan

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,12 +19,12 @@ RUN \
         --no-install-suggests \
       build-essential=11.6ubuntu6 \
       curl=7.35.0-1ubuntu2.6 \
-      git=1:1.9.1-1ubuntu0.2 \
+      git \
       libc6-dev=2.19-0ubuntu6.7 \
       libfontconfig1=2.11.0-0ubuntu4.1 \
       libreadline-dev=6.3-4ubuntu2 \
-      libssl-dev=1.0.1f-1ubuntu2.17 \
-      libssl-doc=1.0.1f-1ubuntu2.17 \
+      libssl-dev \
+      libssl-doc \
       libxml2-dev=2.9.1+dfsg1-3ubuntu4.7 \
       libxslt1-dev=1.1.28-2build1 \
       libyaml-dev=0.1.4-3ubuntu3.1 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -91,6 +91,7 @@ ENV PATH /go/bin:$PATH
 # Node
 RUN ln -s /usr/bin/nodejs /usr/bin/node
 
+<<<<<<< HEAD
 ###
 # Installation
 ###
@@ -151,3 +152,7 @@ WORKDIR $SCANNER_HOME
 VOLUME /data
 
 ENTRYPOINT ["./scan_wrap.sh"]
+
+# pa11y stuff
+RUN npm install --global phantomjs
+RUN npm install --global pa11y

--- a/Dockerfile
+++ b/Dockerfile
@@ -91,7 +91,6 @@ ENV PATH /go/bin:$PATH
 # Node
 RUN ln -s /usr/bin/nodejs /usr/bin/node
 
-<<<<<<< HEAD
 ###
 # Installation
 ###

--- a/scanners/a11y.py
+++ b/scanners/a11y.py
@@ -16,7 +16,7 @@ def get_exitcode_stdout_stderr(cmd):
     proc = Popen(args, stdout=PIPE, stderr=PIPE)
     out, err = proc.communicate()
     exitcode = proc.returncode
-    #
+
     return exitcode, out, err
 
 
@@ -25,27 +25,24 @@ workers = 1
 
 PA11Y_STANDARD = 'WCAG2AA'
 
+headers = [
+    "type",
+    "typeCode",
+    "code",
+    "message",
+    "context",
+    "selector"
+]
+
 def scan(domain, options):
+    print(options)
     command = "pa11y --standard %s --reporter json %s" % (PA11Y_STANDARD, domain)
     exitcode, out, err = get_exitcode_stdout_stderr(command)
     
     reports = json.loads(out.decode("utf-8"))
-    
-    notices = len([r for r in reports if r['type'] == 'notice'])
-    errors = len([r for r in reports if r['type'] == 'error'])
-    warnings = len([r for r in reports if r['type'] == 'warning'])
-        
-    yield [
-        PA11Y_STANDARD,
-        warnings,
-        errors,
-        notices
-    ]
-    
 
-headers = [
-    "Standard",
-    "Warnings",
-    "Errors",
-    "Notices"
-]
+    for report in reports:
+        result = []
+        for header in headers:
+            result.append(report.get(header))
+        yield result

--- a/scanners/a11y.py
+++ b/scanners/a11y.py
@@ -1,0 +1,34 @@
+import logging
+from scanners import utils
+import json
+import os
+
+
+###
+# == tls ==
+#
+# Inspect a site's valid TLS configuration using ssllabs-scan.
+#
+# If data exists for a domain from `inspect`, will check results
+# and only process domains with valid HTTPS, or broken chains.
+###
+
+command = os.environ.get("PA11Y_PATH", "pa11y")
+workers = 1
+
+def scan(domain, options):
+    cmd = [command, "18f.gsa.gov"]
+    result = utils.scan(cmd)
+    print (domain)
+    print(result)
+    yield [
+        "foo",
+        "bar",
+        "baz"
+    ]
+
+headers = [
+    "Errors",
+    "Warnings",
+    "Notices"
+]

--- a/scanners/a11y.py
+++ b/scanners/a11y.py
@@ -5,6 +5,7 @@ import os
 
 import shlex
 from subprocess import Popen, PIPE
+import json
 
 def get_exitcode_stdout_stderr(cmd):
     """
@@ -19,23 +20,32 @@ def get_exitcode_stdout_stderr(cmd):
     return exitcode, out, err
 
 
-
-
 command = os.environ.get("PA11Y_PATH", "pa11y")
 workers = 1
 
+PA11Y_STANDARD = 'WCAG2AA'
+
 def scan(domain, options):
-    command = "pa11y --reporter csv %s" % domain
-
-    cmd = command
-    exitcode, out, err = get_exitcode_stdout_stderr(cmd)
-
-    print(out)
-
-    yield [1,2,3]
+    command = "pa11y --standard %s --reporter json %s" % (PA11Y_STANDARD, domain)
+    exitcode, out, err = get_exitcode_stdout_stderr(command)
+    
+    reports = json.loads(out.decode("utf-8"))
+    
+    notices = len([r for r in reports if r['type'] == 'notice'])
+    errors = len([r for r in reports if r['type'] == 'error'])
+    warnings = len([r for r in reports if r['type'] == 'warning'])
+        
+    yield [
+        PA11Y_STANDARD,
+        warnings,
+        errors,
+        notices
+    ]
+    
 
 headers = [
-    "Errors",
+    "Standard",
     "Warnings",
+    "Errors",
     "Notices"
 ]

--- a/scanners/a11y.py
+++ b/scanners/a11y.py
@@ -3,28 +3,9 @@ from scanners import utils
 import json
 import os
 
-import shlex
-from subprocess import Popen, PIPE
-import json
-
-def get_exitcode_stdout_stderr(cmd):
-    """
-    Execute the external command and get its exitcode, stdout and stderr.
-    """
-    args = shlex.split(cmd)
-
-    proc = Popen(args, stdout=PIPE, stderr=PIPE)
-    out, err = proc.communicate()
-    exitcode = proc.returncode
-
-    return exitcode, out, err
-
-
-command = os.environ.get("PA11Y_PATH", "pa11y")
 workers = 1
-
 PA11Y_STANDARD = 'WCAG2AA'
-
+pa11y = os.environ.get("PA11Y_PATH", "pa11y")
 headers = [
     "type",
     "typeCode",
@@ -35,14 +16,20 @@ headers = [
 ]
 
 def scan(domain, options):
-    print(options)
-    command = "pa11y --standard %s --reporter json %s" % (PA11Y_STANDARD, domain)
-    exitcode, out, err = get_exitcode_stdout_stderr(command)
-    
-    reports = json.loads(out.decode("utf-8"))
+    logging.debug("[%s][a11y]" % domain)
+    # The '--level none' piece here is crucial.
+    # By default, pa11y will return with a non-zero exit code if at least one
+    # error is detected in the scan. Setting '--level none'
+    command = [pa11y, domain, "--reporter", "json", "--standard", PA11Y_STANDARD, "--level", "none"]
+    raw = utils.scan(command)
 
-    for report in reports:
-        result = []
-        for header in headers:
-            result.append(report.get(header))
-        yield result
+    results = json.loads(raw)
+    for data in results:
+        yield [
+            data['type'],
+            data['typeCode'],
+            data['code'],
+            data['message'],
+            data['context'],
+            data['selector']
+        ]

--- a/scanners/a11y.py
+++ b/scanners/a11y.py
@@ -7,7 +7,7 @@ workers = 1
 PA11Y_STANDARD = 'WCAG2AA'
 pa11y = os.environ.get("PA11Y_PATH", "pa11y")
 headers = [
-    "type",
+    "redirectedTo",
     "typeCode",
     "code",
     "message",
@@ -15,18 +15,88 @@ headers = [
     "selector"
 ]
 
-def scan(domain, options):
-    logging.debug("[%s][a11y]" % domain)
-    # The '--level none' piece here is crucial.
-    # By default, pa11y will return with a non-zero exit code if at least one
-    # error is detected in the scan. Setting '--level none'
-    command = [pa11y, domain, "--reporter", "json", "--standard", PA11Y_STANDARD, "--level", "none"]
-    raw = utils.scan(command)
+def get_from_inspect_cache(domain):
+    inspect_cache = utils.cache_path(domain, "inspect")
+    inspect_raw = open(inspect_cache).read()
+    inspect_data = json.loads(inspect_raw)
+    return inspect_data
 
+def get_domain_to_scan(inspect_data, domain):
+    domain_to_scan = None
+    redirect = inspect_data.get('redirect', None)
+    if redirect:
+        domain_to_scan = inspect_data.get('redirect_to')
+    else:
+        domain_to_scan = domain
+    return domain_to_scan
+
+def get_a11y_cache(domain):
+    return utils.cache_path(domain, "a11y")
+
+def domain_is_cached(cache):
+    return os.path.exists(cache)
+
+def cache_is_not_forced(options):
+    return options.get("force", False) is False
+
+def get_errors_from_pa11y_scan(domain, cache):
+    command = [pa11y, domain, "--reporter", "json", "--standard", PA11Y_STANDARD, "--level", "none"]
+    logging.debug("Running a11y command: %s" % command)
+    raw = utils.scan(command)
+    if not raw:
+        utils.write(utils.invalid({}), cache)
+        return []
     results = json.loads(raw)
-    for data in results:
+    errors = get_errors_from_results(results)
+    cachable = json.dumps({'results' : errors})
+    logging.debug("Writing to cache: %s" % domain)
+    utils.write(cachable, cache)
+    return errors
+
+def get_errors_from_results(results):
+    errors = []
+    for result in results:
+        if result['type'] == 'error':
+            errors.append(result)
+    return errors
+
+def get_errors_from_scan_or_cache(domain, options):
+    a11y_cache = get_a11y_cache(domain)
+    the_domain_is_cached = domain_is_cached(a11y_cache)
+    the_cache_is_not_forced = cache_is_not_forced(options)
+    logging.debug("the_domain_is_cached: %s" % the_domain_is_cached)
+    logging.debug("the_cache_is_not_forced: %s" % the_cache_is_not_forced)
+
+    # the_domain_is_cached: True
+    # the_cache_is_not_forced: False
+    if the_domain_is_cached and the_cache_is_not_forced:
+        logging.debug("\tCached.")
+        raw = open(a11y_cache).read()
+        data = json.loads(raw)
+        if data.get('invalid'):
+            return []
+        else:
+            logging.debug("Getting from cache: %s" % domain)
+            results = data.get('results')
+            errors = get_errors_from_results(results)
+            return errors
+    else:
+        logging.debug("\tNot cached.")
+        errors = get_errors_from_pa11y_scan(domain, a11y_cache)
+        return errors
+
+
+def scan(domain, options):
+    logging.debug("[%s]=[a11y]" % domain)
+
+    inspect_data = get_from_inspect_cache(domain)
+    domain_to_scan = get_domain_to_scan(inspect_data, domain)
+    errors = get_errors_from_scan_or_cache(domain_to_scan, options)
+
+    for data in errors:
+        logging.debug("Writing data for %s" % domain)
         yield [
-            data['type'],
+            domain_to_scan,
             data['typeCode'],
             data['code'],
             data['message'],

--- a/scanners/a11y.py
+++ b/scanners/a11y.py
@@ -3,29 +3,36 @@ from scanners import utils
 import json
 import os
 
+import shlex
+from subprocess import Popen, PIPE
 
-###
-# == tls ==
-#
-# Inspect a site's valid TLS configuration using ssllabs-scan.
-#
-# If data exists for a domain from `inspect`, will check results
-# and only process domains with valid HTTPS, or broken chains.
-###
+def get_exitcode_stdout_stderr(cmd):
+    """
+    Execute the external command and get its exitcode, stdout and stderr.
+    """
+    args = shlex.split(cmd)
+
+    proc = Popen(args, stdout=PIPE, stderr=PIPE)
+    out, err = proc.communicate()
+    exitcode = proc.returncode
+    #
+    return exitcode, out, err
+
+
+
 
 command = os.environ.get("PA11Y_PATH", "pa11y")
 workers = 1
 
 def scan(domain, options):
-    cmd = [command, "18f.gsa.gov"]
-    result = utils.scan(cmd)
-    print (domain)
-    print(result)
-    yield [
-        "foo",
-        "bar",
-        "baz"
-    ]
+    command = "pa11y --reporter csv %s" % domain
+
+    cmd = command
+    exitcode, out, err = get_exitcode_stdout_stderr(cmd)
+
+    print(out)
+
+    yield [1,2,3]
 
 headers = [
     "Errors",

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,1 @@
+PA11Y_PATH=/usr/local/bin/pa11y docker-compose run scan 18f.gsa.gov --scan=a11y

--- a/test.sh
+++ b/test.sh
@@ -1,1 +1,1 @@
-PA11Y_PATH=/usr/local/bin/pa11y docker-compose run scan 18f.gsa.gov --scan=a11y
+PA11Y_PATH=/usr/local/bin/pa11y docker-compose run scan gsa.gov --scan=a11y


### PR DESCRIPTION
Close to ready.

Produces a CSV that looks like https://gist.github.com/adelevie/83bb01c024aa05c3b451.

TODOS:
- [ ] Does `PA11Y_PATH` need to be there?
- [ ] Document pa11y dependency requirements. It's all fine in the Dockerfile, but what about the Dockerless?
- [ ] Should we allow the user to alter the scan standard? It currently is hardcoded to WCAG2AA, which is fine for Pulse, but other options are: Section508, WCAG2A, and WCAG2AAA. If so, what's a nice API for that?
- [ ] I'm using some weird thing for getting `stdout` from shelling out to pa11y which skips `util.scan`. I understand this might disrupt Uniform Logging :tm:. 