### PR TITLE
Scanner for producing a list of likely public subdomains from raw data

### DIFF
--- a/scan
+++ b/scan
@@ -48,7 +48,7 @@ def run(options=None):
             exit()
 
         # If the scanner has a canonical command, make sure it exists.
-        if scanner.command and (not utils.try_command(scanner.command)):
+        if hasattr(scanner, "command") and scanner.command and (not utils.try_command(scanner.command)):
             logging.error("[%s] Command not found: %s" %
                           (name, scanner.command))
             exit()

--- a/scan
+++ b/scan
@@ -93,12 +93,17 @@ def scan_domains(scanners, domains):
     # The task wrapper that's parallelized using executor.map.
     def process_scan(params):
         scanner, domain, options = params
-        # A scanner can return multiple rows.
 
-        for row in scanner.scan(domain, options):
+        # A scanner can return multiple rows.
+        try:
+            rows = list(scanner.scan(domain, options))
+        except Exception as e:
+            exc_type, exc_value, exc_traceback = sys.exc_info()
+            print("\tERROR: %s\n\t%s" % (exc_type, exc_value))
+
+        for row in rows:
             if row:
                 handles[scanner]['writer'].writerow([domain] + row)
-
 
     # Run each scanner (unique process pool) over each domain.
     # User can force --serial, and scanners can override default of 10.

--- a/scanners/subdomains.py
+++ b/scanners/subdomains.py
@@ -63,6 +63,7 @@ def scan(domain, options):
         matched_wild = False
     
     yield [
+        base_original,
         inspection["up"],
         redirected_external,
         redirected_subdomain,
@@ -73,6 +74,7 @@ def scan(domain, options):
 
 
 headers = [
+    "Base Domain",
     "Live",
     "Redirects Externally",
     "Redirects To Subdomain",

--- a/scanners/subdomains.py
+++ b/scanners/subdomains.py
@@ -34,12 +34,12 @@ def scan(domain, options):
         logging.debug("\tSkipping, subdomain wasn't up during inspection.")
         return None
 
+    base_original = base_domain_for(domain)
+    sub_original = domain
+
     # If the subdomain redirects anywhere, see if it redirects within the domain
     endpoint = inspection["endpoints"][inspection.get("canonical_protocol")]["root"]
     if endpoint.get("redirect_to"):
-
-        sub_original = domain
-        base_original = base_domain_for(domain)
 
         sub_redirect = urllib.parse.urlparse(endpoint["redirect_to"]).hostname
         sub_redirect = re.sub("^www.", "", sub_redirect) # discount www redirects

--- a/scanners/subdomains.py
+++ b/scanners/subdomains.py
@@ -1,0 +1,64 @@
+import logging
+from scanners import utils
+import json
+import os
+import urllib.request
+import urllib.parse
+import base64
+import re
+
+##
+# == subdomains ==
+#
+# Say whether a subdomain redirects within the domain but to another subdomain.
+# Say whether a subdomain has all numbers in its leftmost subdomain.
+# Say whether a subdomain has any numbers in its leftmost subdomain.
+##
+
+def scan(domain, options):
+    logging.debug("[%s][subdomains]" % domain)
+
+    # If inspection data exists, check to see if we can skip.
+    inspection = utils.data_for(domain, "inspect")
+    if not inspection:
+    	logging.debug("\tSkipping, wasn't inspected.")
+    	return None
+
+    if not inspection.get("up"):
+        logging.debug("\tSkipping, subdomain wasn't up during inspection.")
+        return None
+
+    # If the subdomain redirects anywhere, see if it redirects within the domain
+    endpoint = inspection["endpoints"][inspection.get("canonical_protocol")]["root"]
+    if endpoint.get("redirect_to"):
+
+    	sub_original = domain
+    	base_original = base_domain_for(domain)
+
+    	sub_redirect = urllib.parse.urlparse(endpoint["redirect_to"]).hostname
+    	base_redirect = base_domain_for(sub_redirect)
+    	
+    	redirected_external = base_original != base_redirect
+    	redirected_subdomain = (
+    		(base_original == base_redirect) and 
+    		(sub_original != sub_redirect)
+    	)
+
+    yield [
+    	redirected_external,
+    	redirected_subdomain,
+    	None,
+    	None
+    ]
+
+
+headers = [
+	"Redirects Externally",
+    "Redirects To Subdomain",
+    "All Numbers",
+    "Any Numbers"
+]
+
+# return base domain for a subdomain
+def base_domain_for(subdomain):
+	return str.join(".", subdomain.split(".")[-2:])

--- a/scanners/subdomains.py
+++ b/scanners/subdomains.py
@@ -167,6 +167,7 @@ def scan(domain, options):
     # the signal-to-noise is just too low to include it.
     if matched_wild and (not str(status).startswith('2')):
         logging.debug("\tSkipping, wildcard DNS match with %i status code." % status)
+        return None
 
     yield [
         base_original,

--- a/scanners/subdomains.py
+++ b/scanners/subdomains.py
@@ -19,6 +19,11 @@ import re
 def scan(domain, options):
     logging.debug("[%s][subdomains]" % domain)
 
+    # This only looks at subdomains, remove second-level root's and www's.
+    if re.sub("^www.", "", domain) == base_domain_for(domain):
+        logging.debug("\tSkipping, second-level domain.")
+        return None
+
     # If inspection data exists, check to see if we can skip.
     inspection = utils.data_for(domain, "inspect")
     if not inspection:
@@ -49,15 +54,13 @@ def scan(domain, options):
         redirected_external = False
         redirected_subdomain = False
 
+    # status_code = 
     
     yield [
         inspection["up"],
         redirected_external,
         redirected_subdomain,
         any_numbers(subdomains_for(domain)),
-        all_numbers(subdomains_for(domain)),
-        any_numbers(subbest_domain_for(domain)),
-        all_numbers(subbest_domain_for(domain))
     ]
 
 
@@ -66,18 +69,11 @@ headers = [
     "Redirects Externally",
     "Redirects To Subdomain",
     "Any Numbers",
-    "All Numbers",
-    "Any Numbers (Leftmost)",
-    "All Numbers (Leftmost)"
 ]
 
 # does a number appear anywhere in this thing
 def any_numbers(string):
     return (re.search(r'\d', string) is not None)
-
-# is it all numbers (and dots)
-def all_numbers(string):
-    return (re.search(r'^[\d\.]+$', string) is not None)
 
 # return base domain for a subdomain
 def base_domain_for(subdomain):
@@ -86,7 +82,3 @@ def base_domain_for(subdomain):
 # return everything to the left of the base domain
 def subdomains_for(subdomain):
     return str.join(".", subdomain.split(".")[:-2])
-
-# return the leftmost subdomain
-def subbest_domain_for(subdomain):
-    return subdomain.split(".")[0]

--- a/scanners/subdomains.py
+++ b/scanners/subdomains.py
@@ -2,6 +2,7 @@ import logging
 from scanners import utils
 import json
 import os
+import sys
 import urllib.request
 import urllib.parse
 import base64
@@ -43,22 +44,48 @@ def scan(domain, options):
     		(base_original == base_redirect) and 
     		(sub_original != sub_redirect)
     	)
+    else:
+        redirected_external = False
+        redirected_subdomain = False
 
+    
     yield [
-    	redirected_external,
-    	redirected_subdomain,
-    	None,
-    	None
+        inspection["up"],
+        redirected_external,
+        redirected_subdomain,
+        any_numbers(subdomains_for(domain)),
+        all_numbers(subdomains_for(domain)),
+        any_numbers(subbest_domain_for(domain)),
+        all_numbers(subbest_domain_for(domain))
     ]
 
 
 headers = [
-	"Redirects Externally",
+    "Live",
+    "Redirects Externally",
     "Redirects To Subdomain",
+    "Any Numbers",
     "All Numbers",
-    "Any Numbers"
+    "Any Numbers (Leftmost)",
+    "All Numbers (Leftmost)"
 ]
+
+# does a number appear anywhere in this thing
+def any_numbers(string):
+    return (re.search(r'\d', string) is not None)
+
+# is it all numbers (and dots)
+def all_numbers(string):
+    return (re.search(r'^[\d\.]+$', string) is not None)
 
 # return base domain for a subdomain
 def base_domain_for(subdomain):
 	return str.join(".", subdomain.split(".")[-2:])
+
+# return everything to the left of the base domain
+def subdomains_for(subdomain):
+    return str.join(".", subdomain.split(".")[:-2])
+
+# return the leftmost subdomain
+def subbest_domain_for(subdomain):
+    return subdomain.split(".")[0]

--- a/scanners/subdomains.py
+++ b/scanners/subdomains.py
@@ -22,8 +22,8 @@ def scan(domain, options):
     # If inspection data exists, check to see if we can skip.
     inspection = utils.data_for(domain, "inspect")
     if not inspection:
-    	logging.debug("\tSkipping, wasn't inspected.")
-    	return None
+        logging.debug("\tSkipping, wasn't inspected.")
+        return None
 
     if not inspection.get("up"):
         logging.debug("\tSkipping, subdomain wasn't up during inspection.")
@@ -33,17 +33,18 @@ def scan(domain, options):
     endpoint = inspection["endpoints"][inspection.get("canonical_protocol")]["root"]
     if endpoint.get("redirect_to"):
 
-    	sub_original = domain
-    	base_original = base_domain_for(domain)
+        sub_original = domain
+        base_original = base_domain_for(domain)
 
-    	sub_redirect = urllib.parse.urlparse(endpoint["redirect_to"]).hostname
-    	base_redirect = base_domain_for(sub_redirect)
-    	
-    	redirected_external = base_original != base_redirect
-    	redirected_subdomain = (
-    		(base_original == base_redirect) and 
-    		(sub_original != sub_redirect)
-    	)
+        sub_redirect = urllib.parse.urlparse(endpoint["redirect_to"]).hostname
+        sub_redirect = re.sub("^www.", "", sub_redirect) # discount www redirects
+        base_redirect = base_domain_for(sub_redirect)
+        
+        redirected_external = base_original != base_redirect
+        redirected_subdomain = (
+            (base_original == base_redirect) and 
+            (sub_original != sub_redirect)
+        )
     else:
         redirected_external = False
         redirected_subdomain = False
@@ -80,7 +81,7 @@ def all_numbers(string):
 
 # return base domain for a subdomain
 def base_domain_for(subdomain):
-	return str.join(".", subdomain.split(".")[-2:])
+    return str.join(".", subdomain.split(".")[-2:])
 
 # return everything to the left of the base domain
 def subdomains_for(subdomain):

--- a/scanners/utils.py
+++ b/scanners/utils.py
@@ -144,6 +144,14 @@ def scan(command):
         logging.warn("Error running %s." % (str(command)))
         return None
 
+# Turn shell on, when shell=False won't work.
+def unsafe_execute(command):
+    try:
+        response = subprocess.check_output(command, shell=True)
+        return str(response, encoding='UTF-8')
+    except subprocess.CalledProcessError:
+        logging.warn("Error running %s." % (str(command)))
+        return None
 
 # Predictable cache path for a domain and operation.
 def cache_path(domain, operation):

--- a/scanners/utils.py
+++ b/scanners/utils.py
@@ -180,11 +180,17 @@ def utc_timestamp():
     return strict_rfc3339.now_to_rfc3339_utcoffset()
 
 # Load the first column of a CSV into memory as an array of strings.
-def load_domains(domain_csv):
+def load_domains(domain_csv, whole_rows=False):
     domains = []
     with open(domain_csv, newline='') as csvfile:
         for row in csv.reader(csvfile):
             if (not row[0]) or (row[0].lower().startswith("domain")):
                 continue
-            domains.append(row[0].lower())
+
+            row[0] = row[0].lower()
+            
+            if whole_rows:
+                domains.append(row)
+            else:
+                domains.append(row[0])
     return domains


### PR DESCRIPTION
This scanner takes a CSV full of *potential* subdomains (e.g. a list of DNS requests) and produces a resulting `subdomains.csv` of likely "public websites". We're using this at GSA, in tandem with the official `.gov` domain list.

Given three input files:

1. CSV of potential subdomains (the main input CSV)
2. CSV of subdomains to be excluded (e.g. from manual review)
3. CSV of second-levels with a metadata field in 3rd column (e.g. federal .gov domain list)

This scanner filters out:

* subdomains that didn't get the "inspect" scanner run on them
* subdomains that weren't reachable by HTTP/HTTPS over the public internet
* subdomains that matched a wildcard DNS record AND whose "canonical" endpoint returned a *non-200* status code. 200 status codes should be manually reviewed.
* subdomains which appear on the provided exclusion list (input CSV #2)

And includes fields for:

* Subdomain's parent second-level domain
* Subdomain's parent second-level domain's metadata (input CSV #3)
* Whether the subdomain appears to redirect to another second-level domain
* Whether the subdomain appears to redirect to another subdomain within the same second-level
* The HTTP status code returned by the subdomain's "canonical" endpoint (best guess)
* Whether the subdomain appears to match a wildcard DNS record

The output looks like this:

https://gist.github.com/konklone/7771d390655384110c9a

It's expected that the overall subdomain preparation process is something like:

1. Take the raw input list of potential subdomains.
2. Run them all through the `inspect` and `subdomains` scanners with an empty exclusion list (or perhaps a prior exclusion list), using the official `.gov` list as the parent domain dataset.
3. Take the resulting `subdomains.csv` and manually review the domains which match a wildcard DNS record and whose best-guess canonical endpoint returns a non-200 status code.
4. Take any domains which were manually reviewed and rejected (e.g. typos, obvious gibberish) and append them to the original exclusion list.
5. Re-run the `inspect` and `subdomains` scanners and use the resulting `subdomains.csv` as the final product.
