### PR TITLE
Always include the base domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,25 +1,35 @@
 ## A domain scanner
 
-Scans domains for data on their:
+Scans domains for data on their HTTPS configuration and assorted other things.
 
-* HTTP, HTTPS, and [HSTS](https://https.cio.gov/hsts/) configuration, using [`site-inspector`](https://github.com/benbalter/site-inspector-ruby).
-* Detailed TLS configuration, using the [SSL Labs API](https://github.com/ssllabs/ssllabs-scan).
-* Whether a domain participates in the [Digital Analytics Program](https://analytics.usa.gov). (This one's U.S. government-specific for now, but can be ignored.)
+**Most of the work is farmed out to other command line tools.** The point of this project is to **coordinate** those tools and produce **consistent data output**.
 
-Most of the work is farmed out to other tools. The point of this scanner is to coordinate those tools and produce consistent data output.
-
-Can be used with any domain, or CSV where domains are the first column, such as the [official .gov domain list](https://github.com/GSA/data/tree/gh-pages/dotgov-domains).
+Can be used with any domain, or CSV where domains are the first column, such as the [official .gov domain list](https://catalog.data.gov/dataset/gov-domains-api-c9856).
 
 ### Requirements
 
-* **Python 3**.
-* `inspect` scanner: **[site-inspector](https://github.com/benbalter/site-inspector)**, version **1.0.2 only**.
-* `tls` scanner: **[ssllabs-scan](https://github.com/ssllabs/ssllabs-scan)**, stable branch.
-* `pageload` scanner: **[phantomas](https://www.npmjs.com/package/phantomas)**, installed through npm.
+The requirements here can be quite diverse, because this tool is just a coordinator for other tools. Communication between tools is handled via CLI and STDOUT.
+
+The overall tool requires **Python 3**. To install dependencies:
+
+```bash
+pip install -r requirements.txt
+```
+
+The individual scanners each require their own dependencies. You only need to have the dependencies installed for the scanners you plan to use.
+
+* `inspect` scanner: **Ruby** and **[site-inspector](https://github.com/benbalter/site-inspector)**, version **1.0.2 only**.
+* `tls` scanner: **Go** and **[ssllabs-scan](https://github.com/ssllabs/ssllabs-scan)**, stable branch.
+* `sslyze` scanner: **Python 2** and **[sslyze](https://github.com/nabla-c0d3/sslyze)**, downloaded from [their latest compiled release](https://github.com/nabla-c0d3/sslyze/releases).
+* `pageload` scanner: **Node** and **[phantomas](https://www.npmjs.com/package/phantomas)**, installed through npm.
+
+##### Setting tool paths
 
 Override the path to the `site-inspector` executable by setting the `SITE_INSPECTOR_PATH` environment variable.
 
 Override the path to the `ssllabs-scan` executable by setting the `SSLLABS_PATH` environment variable.
+
+Override the path to the `sslyze.py` executable by setting the `SSLYZE_PATH` environment variable. An env var of `PYENV_VERSION=2.7.9` is passed by default, override version with `SSLYZE_PYENV`.
 
 Override the path to the `phantomas` executable by setting the `PHANTOMAS_PATH` environment variable.
 
@@ -60,11 +70,12 @@ Parallelization will also cause the resulting domains to be written in an unpred
 **Scanners:**
 
 * `inspect` - HTTP/HTTPS/HSTS configuration.
-* `tls` - TLS configuration.
+* `tls` - TLS configuration, using the [SSL Labs API](https://github.com/ssllabs/ssllabs-scan/blob/stable/ssllabs-api-docs.md).
+* `sslyze` - TLS configuration, using the local [`sslyze`](https://github.com/nabla-c0d3/sslyze) command line tool.
 * `analytics` - Participation in an analytics program.
 * `pageload` - Page load and rendering metrics.
 
-**Options:**
+**General options:**
 
 * `--scan` - **Required.** Comma-separated names of one or more scanners.
 * `--sort` - Sort result CSVs by domain name, alphabetically. (**Note:** this causes the entire dataset to be read into memory.)
@@ -74,7 +85,10 @@ Parallelization will also cause the resulting domains to be written in an unpred
 * `--output` - Where to output the `cache/` and `results/` directories. Defaults to `./`.
 * `--force` - Ignore cached data and force scans to hit the network. For the `tls` scanner, this also tells SSL Labs to ignore its server-side cache.
 * `--suffix` - Add a suffix to all input domains. For example, a `--suffix` of `virginia.gov` will add `.virginia.gov` to the end of all input domains.
-* `--analytics` - Required if using the `analytics` scanner. Point this to either a file **or** a URL that contains a CSV of participating domains.
+
+**Scanner-specific options**
+
+* `--analytics` - For the `analytics` scanner. Point this to either a file **or** a URL that contains a CSV of participating domains.
 
 ### Output
 
@@ -116,7 +130,7 @@ Some high-priority TODOs here:
 
 * **JSON output**. Refactor scanners to return a dict instead of a row. Have scanners specify both JSON-style field headers *and* CSV-style column headers in a 2-dimensional array. Use this to make it so JSON and CSV can both be serialized with appropriate fields and in the right order. Include JSON results in the `results/` dir.
 * **Handle network loss gracefully.** Right now, the scanner will assume that a domain is "down" if the network is down, and cache that. That makes trusting the results of a batch run iffy. I don't know the best way to distinguish between a domain being unreachable, and the network *making* the domain unreachable.
-* **Upgrade to site-inspector 2.x.** This repo depends on site-inspector 1.0.2, which is behind the times. But, site-inspector 2 needs more testing and work first. site-inspector 2 also is not backwards-compatible, in CLI syntax or in result format.
+* **Upgrade to site-inspector 3.x.** This repo depends on site-inspector 1.0.2, which is behind the times. But, site-inspector 3 needs more testing and work first. site-inspector 2 also is not backwards-compatible, in CLI syntax or in result format.
 
 ### Public domain
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,6 @@
 ipython
 requests
 strict-rfc3339
+
+lxml
+BeautifulSoup4

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,7 @@ ipython
 requests
 strict-rfc3339
 
+# to support sslyze scanner
 lxml
 BeautifulSoup4
+python-dateutil

--- a/scan
+++ b/scan
@@ -99,7 +99,7 @@ def scan_domains(scanners, domains):
         try:
             rows = list(scanner.scan(domain, options))
         except:
-            print(utils.format_last_exception())
+            logging.warn(utils.format_last_exception())
 
         if rows:
             for row in rows:

--- a/scan
+++ b/scan
@@ -83,7 +83,7 @@ def scan_domains(scanners, domains):
         scanner_filename = "%s/%s.csv" % (utils.results_dir(), name)
         scanner_file = open(scanner_filename, 'w', newline='')
         scanner_writer = csv.writer(scanner_file)
-        scanner_writer.writerow(["Domain"] + scanner.headers)
+        scanner_writer.writerow(["Domain", "Base Domain"] + scanner.headers)
 
         handles[scanner] = {
             'file': scanner_file,
@@ -104,7 +104,7 @@ def scan_domains(scanners, domains):
         if rows:
             for row in rows:
                 if row:
-                    handles[scanner]['writer'].writerow([domain] + row)
+                    handles[scanner]['writer'].writerow([domain, utils.base_domain_for(domain)] + row)
 
     # Run each scanner (unique process pool) over each domain.
     # User can force --serial, and scanners can override default of 10.

--- a/scan
+++ b/scan
@@ -44,7 +44,8 @@ def run(options=None):
         try:
             scanner = importlib.import_module("scanners.%s" % name)
         except ImportError:
-            logging.error("[%s] Scanner not found, or had an error during loading." % name)
+            exc_type, exc_value, exc_traceback = sys.exc_info()
+            logging.error("[%s] Scanner not found, or had an error during loading.\n\tERROR: %s\n\t%s" % (name, exc_type, exc_value))
             exit()
 
         # If the scanner has a canonical command, make sure it exists.
@@ -97,13 +98,13 @@ def scan_domains(scanners, domains):
         # A scanner can return multiple rows.
         try:
             rows = list(scanner.scan(domain, options))
-        except Exception as e:
-            exc_type, exc_value, exc_traceback = sys.exc_info()
-            print("\tERROR: %s\n\t%s" % (exc_type, exc_value))
+        except:
+            print(utils.format_last_exception())
 
-        for row in rows:
-            if row:
-                handles[scanner]['writer'].writerow([domain] + row)
+        if rows:
+            for row in rows:
+                if row:
+                    handles[scanner]['writer'].writerow([domain] + row)
 
     # Run each scanner (unique process pool) over each domain.
     # User can force --serial, and scanners can override default of 10.

--- a/scanners/sslyze.py
+++ b/scanners/sslyze.py
@@ -73,13 +73,14 @@ def scan(domain, options):
 	utils.write(utils.json_for(data), utils.cache_path(domain, "sslyze"))
 
 	yield [
+		base_domain_for(domain),
 		data['sslv2'], data['sslv3'], data['tlsv1.0'], data['tlsv1.1'], data['tlsv1.2'], 
-		
 		data['any_rc4'],
 		data['served_issuer'], data['ocsp_stapling']
 	]
 
 headers = [
+	"Base Domain",
 	"SSLv2", "SSLv3", "TLSv1.0", "TLSv1.1", "TLSv1.2",
 	
 	"Signature Algorithm", "SHA-1 in Chain", 
@@ -145,11 +146,6 @@ def parse_sslyze(xml):
 	return data
 
 
-# headers = [
-# 	"Signature Algorithm", "Key Type", "Key Size",  # strength
-# 	"Forward Secrecy", "OCSP Stapling",  # privacy
-# 	"Fallback SCSV",  # good things
-# 	"RC4", "SSLv3",  # old things
-# 	"TLSv1.2", "SPDY", "Requires SNI",  # forward
-# 	"HTTP/2"  # ever forward
-# ]
+# return base domain for a subdomain
+def base_domain_for(subdomain):
+    return str.join(".", subdomain.split(".")[-2:])

--- a/scanners/sslyze.py
+++ b/scanners/sslyze.py
@@ -82,9 +82,10 @@ def scan(domain, options):
 
 		data['not_before'], data['not_after'],
 
-		data['any_dhe'], data['weakest_dh'],
+		data['any_dhe'], data['all_dhe'],
+		data['weakest_dh'],
 
-		data['any_rc4'],
+		data['any_rc4'], data['all_rc4'],
 		data['served_issuer'], data['ocsp_stapling']
 	]
 
@@ -97,9 +98,10 @@ headers = [
 
 	"Not Before", "Not After",
 
-	"Any Forward Secrecy", "Weakest DH Group Size",
+	"Any Forward Secrecy", "All Forward Secrecy", 
+	"Weakest DH Group Size",
 
-	"Any RC4",
+	"Any RC4", "All RC4",
 	"Highest Served Issuer", "OCSP Stapling"
 ]
 
@@ -176,15 +178,24 @@ def parse_sslyze(xml):
 	# DHE and ECDHE may not remain the only forward secret options for TLS.
 	any_rc4 = False
 	any_dhe = False
+	all_rc4 = True
+	all_dhe = True
 	for cipher in accepted_ciphers:
 		name = cipher["name"]
 		if "RC4" in name:
 			any_rc4 = True
+		else:
+			all_rc4 = False
+
 		if name.startswith("DHE-") or name.startswith("ECDHE-"):
 			any_dhe = True
+		else:
+			all_dhe = False
 
 	data['any_rc4'] = any_rc4
+	data['all_rc4'] = all_rc4
 	data['any_dhe'] = any_dhe
+	data['all_dhe'] = all_dhe
 
 	# Find the weakest available DH group size, if any are available.
 	weakest_dh = 1234567890 # nonsense maximum

--- a/scanners/sslyze.py
+++ b/scanners/sslyze.py
@@ -153,13 +153,17 @@ def parse_sslyze(xml):
 	
 	accepted_ciphers = target.select("acceptedCipherSuites cipherSuite")
 	
-	# Look at accepted cipher suites for RC4 or DHE
+	# Look at accepted cipher suites for RC4 or DHE.
+	# This is imperfect, as the advertising of RC4 could discriminate based on client.
+	# DHE and ECDHE may not remain the only forward secret options for TLS.
 	any_rc4 = False
 	any_dhe = False
 	for cipher in accepted_ciphers:
-		if "RC4" in cipher.text:
+		name = cipher["name"]
+
+		if "RC4" in name:
 			any_rc4 = True
-		if cipher.text.startswith("DHE-") or cipher.text.startswith("ECDHE-"):
+		if name.startswith("DHE-") or name.startswith("ECDHE-"):
 			any_dhe = True
 	data['any_rc4'] = any_rc4
 	data['any_dhe'] = any_dhe

--- a/scanners/sslyze.py
+++ b/scanners/sslyze.py
@@ -28,6 +28,13 @@ def scan(domain, options):
 		logging.debug("\tSkipping, HTTPS not supported in inspection.")
 		return None
 
+	# Optional: if inspect data says canonical endpoint uses www and this domain
+	# doesn't have it, add it.
+	if inspection and (inspection.get("canonical_endpoint") == "www") and (not domain.startswith("www.")):
+		scan_domain = "www.%s" % domain
+	else:
+		scan_domain = domain
+
 	# cache XML from sslyze
 	cache_xml = utils.cache_path(domain, "sslyze", ext="xml")
 	# because sslyze manages its own output (can't yet print to stdout),
@@ -42,7 +49,8 @@ def scan(domain, options):
 
 	else:
 		logging.debug("\t %s %s" % (command, domain))
-		raw = utils.scan([command, "--regular", "--quiet", domain, "--xml_out=%s" % cache_xml], env=command_env)
+		# use scan_domain (possibly www-prefixed) to do actual scan
+		raw = utils.scan([command, "--regular", "--quiet", scan_domain, "--xml_out=%s" % cache_xml], env=command_env)
 		
 		if raw is None:
 			# TODO: save standard invalid XML data...?

--- a/scanners/sslyze.py
+++ b/scanners/sslyze.py
@@ -1,0 +1,147 @@
+import logging
+from scanners import utils
+import json
+import os
+
+from bs4 import BeautifulSoup
+
+###
+# == sslyze ==
+#
+# Inspect a site's TLS configuration using sslyze.
+#
+# If data exists for a domain from `inspect`, will check results
+# and only process domains with valid HTTPS, or broken chains.
+###
+
+command = os.environ.get("SSLYZE_PATH", "sslyze.py")
+
+# Kind of a hack for now, other methods of running sslyze with Python 2 welcome
+command_env = {'PYENV_VERSION': os.environ.get("SSLYZE_PYENV", "2.7.9")}
+
+def scan(domain, options):
+	logging.debug("[%s][sslyze]" % domain)
+
+	# Optional: skip domains which don't support HTTPS in prior inspection
+	inspection = utils.data_for(domain, "inspect")
+	if inspection and (not inspection.get("support_https")):
+		logging.debug("\tSkipping, HTTPS not supported in inspection.")
+		return None
+
+	# cache XML from sslyze
+	cache_xml = utils.cache_path(domain, "sslyze", ext="xml")
+	# because sslyze manages its own output (can't yet print to stdout),
+	# we have to mkdir_p the path ourselves
+	utils.mkdir_p(os.path.dirname(cache_xml))
+
+	force = options.get("force", False)
+
+	if (force is False) and (os.path.exists(cache_xml)):
+		logging.debug("\tCached.")
+		xml = open(cache_xml).read()
+
+	else:
+		logging.debug("\t %s %s" % (command, domain))
+		raw = utils.scan([command, "--regular", "--quiet", domain, "--xml_out=%s" % cache_xml], env=command_env)
+		
+		if raw is None:
+			# TODO: save standard invalid XML data...?
+			logging.warn("\tBad news scanning, sorry!")
+			return None
+
+		xml = utils.scan(["cat", cache_xml])
+		if not xml:
+			logging.warn("\tBad news reading XML, sorry!")
+			return None
+
+		utils.write(xml, cache_xml)
+
+	data = parse_sslyze(xml)
+
+	if data is None:
+		logging.warn("\tNo valid target for scanning, couldn't connect.")
+		return None
+
+	utils.write(utils.json_for(data), utils.cache_path(domain, "sslyze"))
+
+	yield [
+		data['sslv2'], data['sslv3'], data['tlsv1.0'], data['tlsv1.1'], data['tlsv1.2'], 
+		
+		data['any_rc4'],
+		data['served_issuer'], data['ocsp_stapling']
+	]
+
+headers = [
+	"SSLv2", "SSLv3", "TLSv1.0", "TLSv1.1", "TLSv1.2",
+	
+	"Signature Algorithm", "SHA-1 in Chain", 
+	"Key Type", "Key Length",
+
+	"Any RC4",
+	"Highest Served Issuer", "OCSP Stapling"
+]
+
+# Get the relevant fields out of sslyze's XML format. I couldn't find this documented
+# anywhere, so I'm just winging it by looking at example XML.
+def parse_sslyze(xml):
+	
+	doc = BeautifulSoup(xml, "xml")
+
+	# We'll just go after the first found valid target IP.
+	target = doc.select_one("target")
+
+	if target is None:
+		return None
+
+	# Protocol version support.
+	data = {
+		'sslv2': (target.find('sslv2')["isProtocolSupported"] == 'True'),
+		'sslv3': (target.find('sslv3')["isProtocolSupported"] == 'True'),
+		'tlsv1.0': (target.find('tlsv1')["isProtocolSupported"] == 'True'),
+		'tlsv1.1': (target.find('tlsv1_1')["isProtocolSupported"] == 'True'),
+		'tlsv1.2': (target.find('tlsv1_2')["isProtocolSupported"] == 'True')
+	}
+
+	# Whether OCSP stapling is enabled.
+	data['ocsp_stapling'] = (target.select_one('ocspStapling')["isSupported"] == 'True')
+
+	# Find the issuer of the last served cert.
+	# This is an attempt at finding the CA name, but won't work if the served
+	# chain is incomplete. I'll take what I can get without doing path chasing.
+	certificates = target.select("certificateChain certificate")
+	data['served_issuer'] = certificates[-1].select_one("issuer commonName").text
+
+	# Key algorithm and length for leaf certificate only.
+	data['key_type'] = target.select_one("certificateChain certificate[position=leaf] subjectPublicKeyInfo publicKeyAlgorithm").text
+	data['key_length'] = int(target.select_one("certificateChain certificate[position=leaf] subjectPublicKeyInfo publicKeySize").text)
+
+	# Signature of the leaf certificate only.
+	data['leaf_signature'] = target.select_one("certificateChain certificate[position=leaf] signatureAlgorithm").text
+
+	# Look at only served leaf and intermediate certificates
+	signatures = target.select("certificateChain certificate[position=leaf],certificate[position=intermediate] signatureAlgorithm")
+	any_sha1 = False
+	for signature in signatures:
+		if "sha1With" in signature.text:
+			any_sha1 = True
+	data['any_sha1'] = any_sha1
+
+	# Look at accepted cipher suites for the text 'RC4'.
+	accepted_ciphers = target.select("acceptedCipherSuites cipherSuite")
+	any_rc4 = False
+	for cipher in accepted_ciphers:
+		if "RC4" in cipher:
+			any_rc4 = True
+	data['any_rc4'] = any_rc4
+
+	return data
+
+
+# headers = [
+# 	"Signature Algorithm", "Key Type", "Key Size",  # strength
+# 	"Forward Secrecy", "OCSP Stapling",  # privacy
+# 	"Fallback SCSV",  # good things
+# 	"RC4", "SSLv3",  # old things
+# 	"TLSv1.2", "SPDY", "Requires SNI",  # forward
+# 	"HTTP/2"  # ever forward
+# ]

--- a/scanners/sslyze.py
+++ b/scanners/sslyze.py
@@ -125,7 +125,11 @@ def parse_sslyze(xml):
 	}
 
 	# Whether OCSP stapling is enabled.
-	data['ocsp_stapling'] = (target.select_one('ocspStapling')["isSupported"] == 'True')
+	ocsp = target.select_one('ocspStapling')
+	if ocsp:
+		data['ocsp_stapling'] = (ocsp["isSupported"] == 'True')
+	else:
+		data['ocsp_stapling'] = None
 
 	# Find the issuer of the last served cert.
 	# This is an attempt at finding the CA name, but won't work if the served

--- a/scanners/sslyze.py
+++ b/scanners/sslyze.py
@@ -74,7 +74,7 @@ def scan(domain, options):
 	utils.write(utils.json_for(data), utils.cache_path(domain, "sslyze"))
 
 	yield [
-		base_domain_for(domain),
+		utils.base_domain_for(domain),
 
 		data['protocols']['sslv2'], data['protocols']['sslv3'], 
 		data['protocols']['tlsv1.0'], data['protocols']['tlsv1.1'], 
@@ -233,9 +233,4 @@ def parse_sslyze(xml):
 
 
 	return data
-
-
-# return base domain for a subdomain
-def base_domain_for(subdomain):
-    return str.join(".", subdomain.split(".")[-2:])
 

--- a/scanners/sslyze.py
+++ b/scanners/sslyze.py
@@ -74,8 +74,6 @@ def scan(domain, options):
 	utils.write(utils.json_for(data), utils.cache_path(domain, "sslyze"))
 
 	yield [
-		utils.base_domain_for(domain),
-
 		data['protocols']['sslv2'], data['protocols']['sslv3'], 
 		data['protocols']['tlsv1.0'], data['protocols']['tlsv1.1'], 
 		data['protocols']['tlsv1.2'], 
@@ -95,8 +93,6 @@ def scan(domain, options):
 	]
 
 headers = [
-	"Base Domain",
-
 	"SSLv2", "SSLv3", "TLSv1.0", "TLSv1.1", "TLSv1.2",
 
 	"Any Forward Secrecy", "All Forward Secrecy", 

--- a/scanners/subdomains.py
+++ b/scanners/subdomains.py
@@ -76,7 +76,7 @@ def init(options):
 def scan(domain, options):
     logging.debug("[%s][subdomains]" % domain)
 
-    base_original = base_domain_for(domain)
+    base_original = utils.base_domain_for(domain)
     sub_original = domain
 
     base_metadata = domain_map.get(base_original, None)
@@ -144,7 +144,7 @@ def scan(domain, options):
 
         sub_redirect = urllib.parse.urlparse(endpoint["redirect_to"]).hostname
         sub_redirect = re.sub("^www.", "", sub_redirect) # discount www redirects
-        base_redirect = base_domain_for(sub_redirect)
+        base_redirect = utils.base_domain_for(sub_redirect)
         
         redirected_external = base_original != base_redirect
         redirected_subdomain = (
@@ -188,10 +188,6 @@ headers = [
     "Matched Wildcard DNS"
 ]
 
-
-# return base domain for a subdomain
-def base_domain_for(subdomain):
-    return str.join(".", subdomain.split(".")[-2:])
 
 # return everything to the left of the base domain
 def subdomains_for(subdomain):

--- a/scanners/subdomains.py
+++ b/scanners/subdomains.py
@@ -22,6 +22,7 @@ import re
 #
 # This scanner filters out:
 #
+# * second-level domains (or www subdomains)
 # * subdomains that didn't get the "inspect" scanner run on them
 # * subdomains that weren't reachable by HTTP/HTTPS over the public internet
 # * subdomains that matched a wildcard DNS record AND whose "canonical" endpoint 
@@ -30,7 +31,6 @@ import re
 # 
 # And includes fields for:
 #
-# * Subdomain's parent second-level domain
 # * Subdomain's parent second-level domain's metadata (input CSV #3)
 # * Whether the subdomain appears to redirect to another second-level domain
 # * Whether the subdomain appears to redirect to another subdomain within the same second-level
@@ -170,7 +170,6 @@ def scan(domain, options):
         return None
 
     yield [
-        base_original,
         base_metadata,
         redirected_external,
         redirected_subdomain,
@@ -180,7 +179,6 @@ def scan(domain, options):
 
 
 headers = [
-    "Base Domain",
     "Base Domain Info",
     "Redirects Externally",
     "Redirects To Subdomain",

--- a/scanners/utils.py
+++ b/scanners/utils.py
@@ -109,16 +109,16 @@ def results_dir():
 def notify(body):
     try:
         if isinstance(body, Exception):
-            body = format_exception(body)
+            body = format_last_exception()
 
         logging.error(body)  # always print it
 
-    except Exception as exception:
+    except Exception:
         print("Exception logging message to admin, halting as to avoid loop")
-        print(format_exception(exception))
+        print(format_last_exception())
 
 
-def format_exception(exception):
+def format_last_exception():
     exc_type, exc_value, exc_traceback = sys.exc_info()
     return "\n".join(traceback.format_exception(exc_type, exc_value,
                                                 exc_traceback))
@@ -136,9 +136,9 @@ def try_command(command):
         return False
 
 
-def scan(command):
+def scan(command, env=None):
     try:
-        response = subprocess.check_output(command, shell=False)
+        response = subprocess.check_output(command, shell=False, env=env)
         return str(response, encoding='UTF-8')
     except subprocess.CalledProcessError:
         logging.warn("Error running %s." % (str(command)))
@@ -154,8 +154,8 @@ def unsafe_execute(command):
         return None
 
 # Predictable cache path for a domain and operation.
-def cache_path(domain, operation):
-    return os.path.join(cache_dir(), operation, ("%s.json" % domain))
+def cache_path(domain, operation, ext="json"):
+    return os.path.join(cache_dir(), operation, ("%s.%s" % (domain, ext)))
 
 
 # Used to quickly get cached data for a domain.

--- a/scanners/utils.py
+++ b/scanners/utils.py
@@ -179,6 +179,10 @@ def invalid(data=None):
 def utc_timestamp():
     return strict_rfc3339.now_to_rfc3339_utcoffset()
 
+# return base domain for a subdomain
+def base_domain_for(subdomain):
+    return str.join(".", subdomain.split(".")[-2:])
+
 # Load the first column of a CSV into memory as an array of strings.
 def load_domains(domain_csv, whole_rows=False):
     domains = []


### PR DESCRIPTION
This adds a "Base Domain" column to the resulting CSV of every scanner, to the right of the "Domain" column. Now that we're dealing in more subdomains, it's consistently very helpful to be able to sort the results by base domain.