### PR TITLE
Always include the base domain

### DIFF
--- a/scan
+++ b/scan
@@ -83,7 +83,7 @@ def scan_domains(scanners, domains):
         scanner_filename = "%s/%s.csv" % (utils.results_dir(), name)
         scanner_file = open(scanner_filename, 'w', newline='')
         scanner_writer = csv.writer(scanner_file)
-        scanner_writer.writerow(["Domain"] + scanner.headers)
+        scanner_writer.writerow(["Domain", "Base Domain"] + scanner.headers)
 
         handles[scanner] = {
             'file': scanner_file,
@@ -104,7 +104,7 @@ def scan_domains(scanners, domains):
         if rows:
             for row in rows:
                 if row:
-                    handles[scanner]['writer'].writerow([domain] + row)
+                    handles[scanner]['writer'].writerow([domain, utils.base_domain_for(domain)] + row)
 
     # Run each scanner (unique process pool) over each domain.
     # User can force --serial, and scanners can override default of 10.

--- a/scanners/sslyze.py
+++ b/scanners/sslyze.py
@@ -74,8 +74,6 @@ def scan(domain, options):
 	utils.write(utils.json_for(data), utils.cache_path(domain, "sslyze"))
 
 	yield [
-		utils.base_domain_for(domain),
-
 		data['protocols']['sslv2'], data['protocols']['sslv3'], 
 		data['protocols']['tlsv1.0'], data['protocols']['tlsv1.1'], 
 		data['protocols']['tlsv1.2'], 
@@ -95,8 +93,6 @@ def scan(domain, options):
 	]
 
 headers = [
-	"Base Domain",
-
 	"SSLv2", "SSLv3", "TLSv1.0", "TLSv1.1", "TLSv1.2",
 
 	"Any Forward Secrecy", "All Forward Secrecy", 

--- a/scanners/subdomains.py
+++ b/scanners/subdomains.py
@@ -22,6 +22,7 @@ import re
 #
 # This scanner filters out:
 #
+# * second-level domains (or www subdomains)
 # * subdomains that didn't get the "inspect" scanner run on them
 # * subdomains that weren't reachable by HTTP/HTTPS over the public internet
 # * subdomains that matched a wildcard DNS record AND whose "canonical" endpoint 
@@ -30,7 +31,6 @@ import re
 # 
 # And includes fields for:
 #
-# * Subdomain's parent second-level domain
 # * Subdomain's parent second-level domain's metadata (input CSV #3)
 # * Whether the subdomain appears to redirect to another second-level domain
 # * Whether the subdomain appears to redirect to another subdomain within the same second-level
@@ -170,7 +170,6 @@ def scan(domain, options):
         return None
 
     yield [
-        base_original,
         base_metadata,
         redirected_external,
         redirected_subdomain,
@@ -180,7 +179,6 @@ def scan(domain, options):
 
 
 headers = [
-    "Base Domain",
     "Base Domain Info",
     "Redirects Externally",
     "Redirects To Subdomain",


### PR DESCRIPTION
This adds a "Base Domain" column to the resulting CSV of every scanner, to the right of the "Domain" column. Now that we're dealing in more subdomains, it's consistently very helpful to be able to sort the results by base domain.