### PR TITLE
rework dockerfile and add entrypoint functionality

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -66,8 +66,6 @@ RUN pip3 install -r requirements.txt
 # Get RVM.
 RUN gpg --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3
 RUN curl -sSL https://get.rvm.io | bash -s stable --ruby=2.1.5
-      # && apt-get clean \
-      # && rm -rf /var/lib/apt/lists/*
 RUN /bin/bash -l -c "rvm --default use 2.1.5"
 
 # Install Bundler for each version of ruby

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,58 +1,155 @@
-# VERSION 0.0.1
+# VERSION 0.1.1
 
 # USAGE
 
-FROM      ubuntu:14.04
+FROM      ubuntu:14.04.3
 MAINTAINER V. David Zvenyach <vladlen.zvenyach@gsa.gov>
 
-COPY . /tmp/
-WORKDIR /tmp
+###
+# Depenedencies
+###
 
-RUN apt-get update && apt-get install -y python3-pip
+RUN \
+    apt-get update \
+        -qq \
+    && apt-get install \
+        -qq \
+        --yes \
+        --no-install-recommends \
+        --no-install-suggests \
+			build-essential=11.6ubuntu6 \
+			curl=7.35.0-1ubuntu2.5 \
+			git=1:1.9.1-1ubuntu0.1 \
+			libc6-dev=2.19-0ubuntu6.6 \
+			libfontconfig1=2.11.0-0ubuntu4.1 \
+			libreadline-dev=6.3-4ubuntu2 \
+			libssl-dev=1.0.1f-1ubuntu2.15 \
+			libssl-doc=1.0.1f-1ubuntu2.15 \
+			libxml2-dev=2.9.1+dfsg1-3ubuntu4.4 \
+			libxslt1-dev=1.1.28-2build1 \
+			libyaml-dev=0.1.4-3ubuntu3.1 \
+			make=3.81-8.2ubuntu3 \
+			nodejs=0.10.25~dfsg2-2ubuntu1 \
+			npm=1.3.10~dfsg-1 \
+			python3-dev=3.4.0-0ubuntu2 \
+			python3-pip=1.5.4-1ubuntu3 \
+			unzip=6.0-9ubuntu1.3 \
+			wget=1.15-1ubuntu1.14.04.1 \
+			zlib1g-dev=1:1.2.8.dfsg-1ubuntu1 \
+
+			# Preemptively install these so we don't have to clean up after RVM.
+			autoconf=2.69-6 \
+			automake=1:1.14.1-2ubuntu1 \
+			bison=2:3.0.2.dfsg-2 \
+			gawk=1:4.0.1+dfsg-2.1ubuntu2 \
+			libffi-dev=3.1~rc1+r3.0.13-12 \
+			libgdbm-dev=1.8.3-12build1 \
+			libncurses5-dev=5.9+20140118-1ubuntu1 \
+			libsqlite3-dev=3.8.2-1ubuntu2.1 \
+			libtool=2.4.2-1.7ubuntu1 \
+			pkg-config=0.26-1ubuntu4 \
+			sqlite3=3.8.2-1ubuntu2.1 \
+
+# Clean up packages.
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+###
+## Python
+
+COPY requirements.txt requirements.txt
 RUN pip3 install -r requirements.txt
 
-# Install ruby
-RUN apt-get update && apt-get install -y libc6-dev libssl-doc build-essential curl git zlib1g-dev libssl-dev libreadline-dev libyaml-dev libxml2-dev libxslt-dev
-RUN apt-get clean
+###
+# Ruby
 
-# Install rbenv and ruby-build
-RUN git clone https://github.com/sstephenson/rbenv.git /tmp/.rbenv
-RUN git clone https://github.com/sstephenson/ruby-build.git /tmp/.rbenv/plugins/ruby-build
-RUN /bin/bash -l -c "/tmp/.rbenv/plugins/ruby-build/install.sh"
-ENV PATH /tmp/.rbenv/bin:/root/.rbenv/versions/2.1.4/bin:$PATH
+# Get RVM.
+RUN gpg --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3
+RUN curl -sSL https://get.rvm.io | bash -s stable --ruby=2.1.5
+			# && apt-get clean \
+			# && rm -rf /var/lib/apt/lists/*
+RUN /bin/bash -l -c "rvm --default use 2.1.5"
 
-RUN echo 'eval "$(rbenv init -)"' >> /etc/profile.d/rbenv.sh # or /etc/profile
-RUN echo 'eval "$(rbenv init -)"' >> .bashrc
-RUN /bin/bash -l -c "rbenv install 2.1.4"
-RUN /bin/bash -l -c "rbenv global 2.1.4"
-RUN /bin/bash -l -c "rbenv rehash"
 # Install Bundler for each version of ruby
-RUN /bin/bash -l -c "gem install bundler"
-RUN /bin/bash -l -c "gem install site-inspector -v 1.0.2"
+RUN /bin/bash -l -c "gem install bundler --no-ri --no-rdoc"
+RUN /bin/bash -l -c "gem install site-inspector -v 1.0.2 --no-ri --no-rdoc"
 
-# Install Go
-RUN apt-get update && apt-get install -y \
-		gcc libc6-dev make \
-		--no-install-recommends \
-	&& rm -rf /var/lib/apt/lists/*
+###
+# Go
 
 ENV GOLANG_VERSION 1.3.3
 
-RUN curl -sSL https://golang.org/dl/go$GOLANG_VERSION.src.tar.gz \
+RUN curl -sSL https://golang.org/dl/go${GOLANG_VERSION}.src.tar.gz \
 		| tar -v -C /usr/src -xz
 
-RUN cd /usr/src/go/src && ./make.bash --no-clean 2>&1
+RUN cd /usr/src/go/src \
+			&& ./make.bash --no-clean 2>&1
 
 ENV PATH /usr/src/go/bin:$PATH
-
-RUN mkdir -p /go/src /go/bin && chmod -R 777 /go
 ENV GOPATH /go
 ENV PATH /go/bin:$PATH
-RUN go get github.com/ssllabs/ssllabs-scan
 
-# Install Node and Phantomas
-RUN apt-get update && apt-get install -y nodejs npm libfontconfig1
+###
+# Node
 RUN ln -s /usr/bin/nodejs /usr/bin/node
-RUN npm install --global phantomas
 
-ENTRYPOINT ["/tmp/scan"]
+###
+# Installation
+###
+
+###
+# ssllabs-scan
+
+RUN mkdir -p /go/src /go/bin \
+			&& chmod -R 777 /go
+RUN go get github.com/ssllabs/ssllabs-scan
+ENV SSLLABS_PATH /go/bin/ssllabs-scan
+
+###
+# phantomas
+
+RUN npm install \
+			--silent \
+			--global \
+		phantomas
+
+###
+# sslyze
+
+ENV SSLYZE_VERSION 0.11
+ENV SSLYZE_FILE sslyze-0_11-linux64.zip
+ENV SSLYZE_DEST /opt
+
+# Would be nice if bash string manipulation worked in ENV as this could use:
+# ${SSLYZE_FILE%.*}
+ENV SSLYZE_PATH ${SSLYZE_DEST}/sslyze-0_11-linux64/sslyze/sslyze.py
+RUN wget https://github.com/nabla-c0d3/sslyze/releases/download/release-${SSLYZE_VERSION}/${SSLYZE_FILE} \
+			--no-verbose \
+	&& unzip $SSLYZE_FILE -d $SSLYZE_DEST
+
+###
+# Create Unprivileged User
+###
+
+ENV SCANNER_HOME /home/scanner
+RUN mkdir $SCANNER_HOME
+
+COPY . $SCANNER_HOME
+
+RUN echo ". /usr/local/rvm/scripts/rvm" > $SCANNER_HOME/.bashrc
+
+RUN groupadd -r scanner \
+  && useradd -r -c "Scanner user" -g scanner scanner \
+	&& chown -R scanner:scanner ${SCANNER_HOME} \
+	&& usermod -a -G rvm scanner
+
+###
+# Prepare to Run
+###
+
+WORKDIR $SCANNER_HOME
+
+# Volume mount for use with the 'data' option.
+VOLUME /data
+
+ENTRYPOINT ["./scan_wrap.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,38 +17,38 @@ RUN \
         --yes \
         --no-install-recommends \
         --no-install-suggests \
-			build-essential=11.6ubuntu6 \
-			curl=7.35.0-1ubuntu2.5 \
-			git=1:1.9.1-1ubuntu0.1 \
-			libc6-dev=2.19-0ubuntu6.6 \
-			libfontconfig1=2.11.0-0ubuntu4.1 \
-			libreadline-dev=6.3-4ubuntu2 \
-			libssl-dev=1.0.1f-1ubuntu2.15 \
-			libssl-doc=1.0.1f-1ubuntu2.15 \
-			libxml2-dev=2.9.1+dfsg1-3ubuntu4.4 \
-			libxslt1-dev=1.1.28-2build1 \
-			libyaml-dev=0.1.4-3ubuntu3.1 \
-			make=3.81-8.2ubuntu3 \
-			nodejs=0.10.25~dfsg2-2ubuntu1 \
-			npm=1.3.10~dfsg-1 \
-			python3-dev=3.4.0-0ubuntu2 \
-			python3-pip=1.5.4-1ubuntu3 \
-			unzip=6.0-9ubuntu1.3 \
-			wget=1.15-1ubuntu1.14.04.1 \
-			zlib1g-dev=1:1.2.8.dfsg-1ubuntu1 \
+      build-essential=11.6ubuntu6 \
+      curl=7.35.0-1ubuntu2.5 \
+      git=1:1.9.1-1ubuntu0.1 \
+      libc6-dev=2.19-0ubuntu6.6 \
+      libfontconfig1=2.11.0-0ubuntu4.1 \
+      libreadline-dev=6.3-4ubuntu2 \
+      libssl-dev=1.0.1f-1ubuntu2.15 \
+      libssl-doc=1.0.1f-1ubuntu2.15 \
+      libxml2-dev=2.9.1+dfsg1-3ubuntu4.4 \
+      libxslt1-dev=1.1.28-2build1 \
+      libyaml-dev=0.1.4-3ubuntu3.1 \
+      make=3.81-8.2ubuntu3 \
+      nodejs=0.10.25~dfsg2-2ubuntu1 \
+      npm=1.3.10~dfsg-1 \
+      python3-dev=3.4.0-0ubuntu2 \
+      python3-pip=1.5.4-1ubuntu3 \
+      unzip=6.0-9ubuntu1.3 \
+      wget=1.15-1ubuntu1.14.04.1 \
+      zlib1g-dev=1:1.2.8.dfsg-1ubuntu1 \
 
-			# Preemptively install these so we don't have to clean up after RVM.
-			autoconf=2.69-6 \
-			automake=1:1.14.1-2ubuntu1 \
-			bison=2:3.0.2.dfsg-2 \
-			gawk=1:4.0.1+dfsg-2.1ubuntu2 \
-			libffi-dev=3.1~rc1+r3.0.13-12 \
-			libgdbm-dev=1.8.3-12build1 \
-			libncurses5-dev=5.9+20140118-1ubuntu1 \
-			libsqlite3-dev=3.8.2-1ubuntu2.1 \
-			libtool=2.4.2-1.7ubuntu1 \
-			pkg-config=0.26-1ubuntu4 \
-			sqlite3=3.8.2-1ubuntu2.1 \
+      # Preemptively install these so we don't have to clean up after RVM.
+      autoconf=2.69-6 \
+      automake=1:1.14.1-2ubuntu1 \
+      bison=2:3.0.2.dfsg-2 \
+      gawk=1:4.0.1+dfsg-2.1ubuntu2 \
+      libffi-dev=3.1~rc1+r3.0.13-12 \
+      libgdbm-dev=1.8.3-12build1 \
+      libncurses5-dev=5.9+20140118-1ubuntu1 \
+      libsqlite3-dev=3.8.2-1ubuntu2.1 \
+      libtool=2.4.2-1.7ubuntu1 \
+      pkg-config=0.26-1ubuntu4 \
+      sqlite3=3.8.2-1ubuntu2.1 \
 
 # Clean up packages.
     && apt-get clean \
@@ -66,8 +66,8 @@ RUN pip3 install -r requirements.txt
 # Get RVM.
 RUN gpg --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3
 RUN curl -sSL https://get.rvm.io | bash -s stable --ruby=2.1.5
-			# && apt-get clean \
-			# && rm -rf /var/lib/apt/lists/*
+      # && apt-get clean \
+      # && rm -rf /var/lib/apt/lists/*
 RUN /bin/bash -l -c "rvm --default use 2.1.5"
 
 # Install Bundler for each version of ruby
@@ -80,10 +80,10 @@ RUN /bin/bash -l -c "gem install site-inspector -v 1.0.2 --no-ri --no-rdoc"
 ENV GOLANG_VERSION 1.3.3
 
 RUN curl -sSL https://golang.org/dl/go${GOLANG_VERSION}.src.tar.gz \
-		| tar -v -C /usr/src -xz
+    | tar -v -C /usr/src -xz
 
 RUN cd /usr/src/go/src \
-			&& ./make.bash --no-clean 2>&1
+      && ./make.bash --no-clean 2>&1
 
 ENV PATH /usr/src/go/bin:$PATH
 ENV GOPATH /go
@@ -101,7 +101,7 @@ RUN ln -s /usr/bin/nodejs /usr/bin/node
 # ssllabs-scan
 
 RUN mkdir -p /go/src /go/bin \
-			&& chmod -R 777 /go
+      && chmod -R 777 /go
 RUN go get github.com/ssllabs/ssllabs-scan
 ENV SSLLABS_PATH /go/bin/ssllabs-scan
 
@@ -109,9 +109,9 @@ ENV SSLLABS_PATH /go/bin/ssllabs-scan
 # phantomas
 
 RUN npm install \
-			--silent \
-			--global \
-		phantomas
+      --silent \
+      --global \
+    phantomas
 
 ###
 # sslyze
@@ -124,8 +124,8 @@ ENV SSLYZE_DEST /opt
 # ${SSLYZE_FILE%.*}
 ENV SSLYZE_PATH ${SSLYZE_DEST}/sslyze-0_11-linux64/sslyze/sslyze.py
 RUN wget https://github.com/nabla-c0d3/sslyze/releases/download/release-${SSLYZE_VERSION}/${SSLYZE_FILE} \
-			--no-verbose \
-	&& unzip $SSLYZE_FILE -d $SSLYZE_DEST
+      --no-verbose \
+  && unzip $SSLYZE_FILE -d $SSLYZE_DEST
 
 ###
 # Create Unprivileged User
@@ -140,8 +140,8 @@ RUN echo ". /usr/local/rvm/scripts/rvm" > $SCANNER_HOME/.bashrc
 
 RUN groupadd -r scanner \
   && useradd -r -c "Scanner user" -g scanner scanner \
-	&& chown -R scanner:scanner ${SCANNER_HOME} \
-	&& usermod -a -G rvm scanner
+  && chown -R scanner:scanner ${SCANNER_HOME} \
+  && usermod -a -G rvm scanner
 
 ###
 # Prepare to Run

--- a/scan_wrap.sh
+++ b/scan_wrap.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+set -e
+
+# Rather not worry about the intersection of RVM, ENTRYPOINT and profile
+# sourcing. This just works.
+. /usr/local/rvm/scripts/rvm
+
+# Run the scan with passthrough arguments.
+case $1 in
+  drop  )
+    # Switch to the scanner user while keeping the current env and passing
+    # through the current arguments stripped of the 'drop' option.
+    sudo -E -u scanner -H bash -l -s ./scan "${@:2}" <<'EOF'
+      "$@"
+EOF
+    ;;
+  data  )
+    ./scan "${@:2}" --output=/data
+    ;;
+  *     )
+    ./scan $@
+    ;;
+esac


### PR DESCRIPTION
I wanted to use the docker image to check out collegescorecard and ran into a problem or two. I got it working and added a few things I wanted.

- Pins the version of all package dependencies, very nice to have when doing automated builds.
- Uses RVM instead of Rbenv for the benefit of grabbing a straightforward Ruby binary instead of compiling.
- Adds sslyze 0.11 which seemed to be missing?
- Adds a volume mountpoint at `/data`.
- Adds the `scanner` user for running without root.
- Adds an entrypoint wrapper script with 3 modes.
    - (blank) : Runs everything unchanged (root, output to ./).

         ```
        docker run \
domain-scan \
google.com --scan=inspect,tls,pageload,sslyze
        ```
    - drop : Runs scan as the scanner user.

         ```
        docker run --rm \
domain-scan \
drop \
google.com --scan=inspect,tls,pageload,sslyze
        ```
    - data : Outputs to the `/data` mountpoint, for use with with something like...

        ```
        docker run --rm \
-v /home/ubuntu:/data \
domain-scan \
data \
google.com --scan=inspect,tls,pageload,sslyze
        ```
    ...which will output `cache` and `results` to the host machine `/home/ubuntu` directory.

