### PR TITLE
Move workers down to 1 for SSL Labs API

### DIFF
--- a/scanners/tls.py
+++ b/scanners/tls.py
@@ -14,7 +14,7 @@ import os
 ###
 
 command = os.environ.get("SSLLABS_PATH", "ssllabs-scan")
-workers = 5
+workers = 1
 
 
 def scan(domain, options):


### PR DESCRIPTION
We're getting killed on SSL Labs' rate limiting, and dropping a number of requests. This causes SSL Labs data to flux in and out each week, and in general means we're just not publishing complete scans and grades.

I thought that the `ssllabs-scan` client was taking care of rate limiting naturally, and waiting/retrying domains when it receives a rate limit response code (429). However, on July 30th, SSL Labs changed this behavior in https://github.com/ssllabs/ssllabs-scan/commit/dc38cfbb96cefb3d37c1de5421f093aafbc6f0bc to move the wait/retry logic out of the individual goroutine and into the `ssllabs-scan` client's own batching logic. We updated our client version at some point after that, at which point this started becoming a problem.

Since `domain-scan` does its **own** parallelization, and spawns a bunch of isolated processes that each tackle one domain (rather than handing a bunch of domains to `ssllabs-scan` and letting it use its own internal batching), this effectively means we lost the benefit of `ssllabs-scan` doing the retries for us.

I think we're getting punished more for the rapidity with which we start new scans than trying to run more simultaneously than the server can hold, but in any case, I'm not psyched about building in batch retry logic to `domain-scan`. So, this drops the worker number for SSL Labs down to 1. I'm testing this now on the server, and testing alternate #'s (like 2 and 3), to see the effect. I won't merge until I have more information.

In any case, I think our scans are likely to take considerably longer than before. However, there's no way for us to present this grade just by using `sslyze`, and the grade is a powerful motivator for IT teams. I'll post more here when I have it.