### PR TITLE
Docker tweaks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ RUN \
       build-essential=11.6ubuntu6 \
       curl=7.35.0-1ubuntu2.6 \
       git \
-      libc6-dev=2.19-0ubuntu6.7 \
+      libc6-dev \
       libfontconfig1=2.11.0-0ubuntu4.1 \
       libreadline-dev=6.3-4ubuntu2 \
       libssl-dev \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
 scan:
   build: .
   volumes:
-  - ./:/tmp
+  - ./:/home/scanner


### PR DESCRIPTION
Two changes to get me up and running with Docker:

- Removed a hardcoded version of libc6-dev. Before, `docker-compose build` was breaking at this part. I know it's best practice to have these versions pinned down. But I don't know how to do that. I'll learn it and do it later.

- Use `/home/scanner` as a shared volume with the host. This allows the user to access the results of a scan in the host. Before, you could run scans, but the results were inaccessible, deep inside the container.