### PR TITLE
run (some) scanners in their own Docker containers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,19 +50,6 @@ RUN \
       apparmor \
       docker-engine \
 
-      # Preemptively install these so we don't have to clean up after RVM.
-      autoconf=2.69-6 \
-      automake=1:1.14.1-2ubuntu1 \
-      bison=2:3.0.2.dfsg-2 \
-      gawk=1:4.0.1+dfsg-2.1ubuntu2 \
-      libffi-dev=3.1~rc1+r3.0.13-12ubuntu0.1 \
-      libgdbm-dev=1.8.3-12build1 \
-      libncurses5-dev=5.9+20140118-1ubuntu1 \
-      libsqlite3-dev=3.8.2-1ubuntu2.1 \
-      libtool=2.4.2-1.7ubuntu1 \
-      pkg-config=0.26-1ubuntu4 \
-      sqlite3=3.8.2-1ubuntu2.1 \
-
       # Additional dependencies for python-build
       libbz2-dev \
       llvm \
@@ -71,16 +58,6 @@ RUN \
     # Clean up packages.
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
-
-###
-# Ruby
-
-# Get RVM.
-RUN gpg --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3
-RUN curl -sSL https://get.rvm.io | bash -s stable --ruby=2.1.5
-RUN /bin/bash -l -c "rvm --default use 2.1.5"
-
-RUN /bin/bash -l -c "gem install site-inspector -v 1.0.2 --no-ri --no-rdoc"
 
 ###
 # Python dependencies
@@ -97,12 +74,9 @@ RUN mkdir $SCANNER_HOME
 
 COPY . $SCANNER_HOME
 
-RUN echo ". /usr/local/rvm/scripts/rvm" > $SCANNER_HOME/.bashrc
-
 RUN groupadd -r scanner \
   && useradd -r -c "Scanner user" -g scanner scanner \
-  && chown -R scanner:scanner ${SCANNER_HOME} \
-  && usermod -a -G rvm scanner
+  && chown -R scanner:scanner ${SCANNER_HOME}
 
 ###
 # Prepare to Run

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,15 +2,15 @@
 
 # USAGE
 
-FROM      ubuntu:14.04.4
+FROM python:3-onbuild
 MAINTAINER V. David Zvenyach <vladlen.zvenyach@gsa.gov>
 
 ###
-# Depenedencies
+# Docker
 ###
 
 RUN \
-    # https://docs.docker.com/engine/installation/linux/ubuntulinux/#update-your-apt-sources
+    # https://docs.docker.com/engine/installation/linux/ubuntulinux/
     apt-get update \
         -qq \
     && apt-get install \
@@ -24,65 +24,29 @@ RUN \
     && echo deb https://apt.dockerproject.org/repo ubuntu-trusty main > /etc/apt/sources.list.d/docker.list \
     && apt-get update \
         -qq \
-    && apt-get purge lxc-docker \
-
     && apt-get install \
         -qq \
         --yes \
         --no-install-recommends \
         --no-install-suggests \
-      build-essential=11.6ubuntu6 \
-      curl=7.35.0-1ubuntu2.6 \
-      git \
-      libc6-dev \
-      libfontconfig1=2.11.0-0ubuntu4.1 \
-      libreadline-dev=6.3-4ubuntu2 \
-      libssl-dev \
-      libssl-doc \
-      libxml2-dev=2.9.1+dfsg1-3ubuntu4.7 \
-      libxslt1-dev=1.1.28-2build1 \
-      libyaml-dev=0.1.4-3ubuntu3.1 \
-      python3-dev=3.4.0-0ubuntu2 \
-      python3-pip=1.5.4-1ubuntu3 \
-      zlib1g-dev=1:1.2.8.dfsg-1ubuntu1 \
-
-      # https://docs.docker.com/engine/installation/linux/ubuntulinux/
       apparmor \
       docker-engine \
-
-      # Additional dependencies for python-build
-      libbz2-dev \
-      llvm \
-      libncursesw5-dev \
 
     # Clean up packages.
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
 ###
-# Python dependencies
-
-COPY requirements.txt requirements.txt
-RUN pip3 install -r requirements.txt
-
-###
 # Create Unprivileged User
 ###
 
-ENV SCANNER_HOME /home/scanner
-RUN mkdir $SCANNER_HOME
-
-COPY . $SCANNER_HOME
-
 RUN groupadd -r scanner \
   && useradd -r -c "Scanner user" -g scanner scanner \
-  && chown -R scanner:scanner ${SCANNER_HOME}
+  && chown -R scanner:scanner /usr/src/app
 
 ###
 # Prepare to Run
 ###
-
-WORKDIR $SCANNER_HOME
 
 # Volume mount for use with the 'data' option.
 VOLUME /data

--- a/Dockerfile
+++ b/Dockerfile
@@ -47,8 +47,6 @@ RUN \
       npm=1.3.10~dfsg-1 \
       python3-dev=3.4.0-0ubuntu2 \
       python3-pip=1.5.4-1ubuntu3 \
-      unzip=6.0-9ubuntu1.5 \
-      wget=1.15-1ubuntu1.14.04.1 \
       zlib1g-dev=1:1.2.8.dfsg-1ubuntu1 \
 
       # https://docs.docker.com/engine/installation/linux/ubuntulinux/
@@ -76,25 +74,6 @@ RUN \
     # Clean up packages.
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
-
-###
-## Python
-
-ENV PYENV_FILE v20160310.zip
-ENV PYENV_ROOT /opt/pyenv
-
-RUN wget https://github.com/yyuu/pyenv/archive/${PYENV_FILE} \
-      --no-verbose \
-  && unzip $PYENV_FILE -d $PYENV_ROOT \
-  && mv $PYENV_ROOT/pyenv-20160310/* $PYENV_ROOT/ \
-  && rm -r $PYENV_ROOT/pyenv-20160310
-
-ENV PATH $PYENV_ROOT/bin:$PATH
-
-RUN echo 'eval "$(pyenv init -)"' >> /etc/profile \
-    && eval "$(pyenv init -)" \
-    && pyenv install 3.5.0 \
-    && pyenv local 3.5.0
 
 COPY requirements.txt requirements.txt
 RUN pip3 install -r requirements.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,8 +10,22 @@ MAINTAINER V. David Zvenyach <vladlen.zvenyach@gsa.gov>
 ###
 
 RUN \
+    # https://docs.docker.com/engine/installation/linux/ubuntulinux/#update-your-apt-sources
     apt-get update \
         -qq \
+    && apt-get install \
+        -qq \
+        --yes \
+        --no-install-recommends \
+        --no-install-suggests \
+      apt-transport-https \
+      ca-certificates \
+    && apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 58118E89F3A912897C070ADBF76221572C52609D \
+    && echo deb https://apt.dockerproject.org/repo ubuntu-trusty main > /etc/apt/sources.list.d/docker.list \
+    && apt-get update \
+        -qq \
+    && apt-get purge lxc-docker \
+
     && apt-get install \
         -qq \
         --yes \
@@ -36,6 +50,10 @@ RUN \
       unzip=6.0-9ubuntu1.5 \
       wget=1.15-1ubuntu1.14.04.1 \
       zlib1g-dev=1:1.2.8.dfsg-1ubuntu1 \
+
+      # https://docs.docker.com/engine/installation/linux/ubuntulinux/
+      apparmor \
+      docker-engine \
 
       # Preemptively install these so we don't have to clean up after RVM.
       autoconf=2.69-6 \
@@ -131,29 +149,6 @@ RUN npm install \
       --silent \
       --global \
     phantomas
-
-###
-# docker
-
-# https://docs.docker.com/engine/installation/linux/ubuntulinux/
-RUN apt-get install \
-      -qq \
-      --yes \
-      --no-install-recommends \
-      --no-install-suggests \
-    apt-transport-https \
-    ca-certificates
-RUN apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 58118E89F3A912897C070ADBF76221572C52609D
-RUN echo deb https://apt.dockerproject.org/repo ubuntu-trusty main > /etc/apt/sources.list.d/docker.list
-RUN apt-get update
-RUN apt-get purge lxc-docker
-RUN apt-get install \
-      -qq \
-      --yes \
-      --no-install-recommends \
-      --no-install-suggests \
-    apparmor \
-    docker-engine
 
 ###
 # Create Unprivileged User

--- a/Dockerfile
+++ b/Dockerfile
@@ -75,7 +75,6 @@ ENV PATH $PYENV_ROOT/bin:$PATH
 
 RUN echo 'eval "$(pyenv init -)"' >> /etc/profile \
     && eval "$(pyenv init -)" \
-    && pyenv install 2.7.11 \
     && pyenv install 3.5.0 \
     && pyenv local 3.5.0
 
@@ -134,18 +133,27 @@ RUN npm install \
     phantomas
 
 ###
-# sslyze
+# docker
 
-ENV SSLYZE_VERSION 0.11
-ENV SSLYZE_FILE sslyze-0_11-linux64.zip
-ENV SSLYZE_DEST /opt
-
-# Would be nice if bash string manipulation worked in ENV as this could use:
-# ${SSLYZE_FILE%.*}
-ENV SSLYZE_PATH ${SSLYZE_DEST}/sslyze-0_11-linux64/sslyze/sslyze.py
-RUN wget https://github.com/nabla-c0d3/sslyze/releases/download/release-${SSLYZE_VERSION}/${SSLYZE_FILE} \
-      --no-verbose \
-  && unzip $SSLYZE_FILE -d $SSLYZE_DEST
+# https://docs.docker.com/engine/installation/linux/ubuntulinux/
+RUN apt-get install \
+      -qq \
+      --yes \
+      --no-install-recommends \
+      --no-install-suggests \
+    apt-transport-https \
+    ca-certificates
+RUN apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 58118E89F3A912897C070ADBF76221572C52609D
+RUN echo deb https://apt.dockerproject.org/repo ubuntu-trusty main > /etc/apt/sources.list.d/docker.list
+RUN apt-get update
+RUN apt-get purge lxc-docker
+RUN apt-get install \
+      -qq \
+      --yes \
+      --no-install-recommends \
+      --no-install-suggests \
+    apparmor \
+    docker-engine
 
 ###
 # Create Unprivileged User

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 
 # USAGE
 
-FROM python:3-onbuild
+FROM python:3
 MAINTAINER V. David Zvenyach <vladlen.zvenyach@gsa.gov>
 
 ###
@@ -37,16 +37,29 @@ RUN \
     && rm -rf /var/lib/apt/lists/*
 
 ###
+# Python dependencies
+
+COPY requirements.txt requirements.txt
+RUN pip3 install --no-cache-dir -r requirements.txt
+
+###
 # Create Unprivileged User
 ###
 
+ENV SCANNER_HOME /home/scanner
+RUN mkdir $SCANNER_HOME
+
+COPY . $SCANNER_HOME
+
 RUN groupadd -r scanner \
   && useradd -r -c "Scanner user" -g scanner scanner \
-  && chown -R scanner:scanner /usr/src/app
+  && chown -R scanner:scanner ${SCANNER_HOME}
 
 ###
 # Prepare to Run
 ###
+
+WORKDIR $SCANNER_HOME
 
 # Volume mount for use with the 'data' option.
 VOLUME /data

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,8 +42,6 @@ RUN \
       libxml2-dev=2.9.1+dfsg1-3ubuntu4.7 \
       libxslt1-dev=1.1.28-2build1 \
       libyaml-dev=0.1.4-3ubuntu3.1 \
-      nodejs=0.10.25~dfsg2-2ubuntu1 \
-      npm=1.3.10~dfsg-1 \
       python3-dev=3.4.0-0ubuntu2 \
       python3-pip=1.5.4-1ubuntu3 \
       zlib1g-dev=1:1.2.8.dfsg-1ubuntu1 \
@@ -74,9 +72,6 @@ RUN \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-COPY requirements.txt requirements.txt
-RUN pip3 install -r requirements.txt
-
 ###
 # Ruby
 
@@ -85,25 +80,13 @@ RUN gpg --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A170311380
 RUN curl -sSL https://get.rvm.io | bash -s stable --ruby=2.1.5
 RUN /bin/bash -l -c "rvm --default use 2.1.5"
 
-# Install Bundler for each version of ruby
-RUN /bin/bash -l -c "gem install bundler --no-ri --no-rdoc"
 RUN /bin/bash -l -c "gem install site-inspector -v 1.0.2 --no-ri --no-rdoc"
 
 ###
-# Node
-RUN ln -s /usr/bin/nodejs /usr/bin/node
+# Python dependencies
 
-###
-# Installation
-###
-
-###
-# phantomas
-
-RUN npm install \
-      --silent \
-      --global \
-    phantomas
+COPY requirements.txt requirements.txt
+RUN pip3 install -r requirements.txt
 
 ###
 # Create Unprivileged User

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,6 @@ RUN \
       libxml2-dev=2.9.1+dfsg1-3ubuntu4.7 \
       libxslt1-dev=1.1.28-2build1 \
       libyaml-dev=0.1.4-3ubuntu3.1 \
-      make=3.81-8.2ubuntu3 \
       nodejs=0.10.25~dfsg2-2ubuntu1 \
       npm=1.3.10~dfsg-1 \
       python3-dev=3.4.0-0ubuntu2 \
@@ -91,35 +90,12 @@ RUN /bin/bash -l -c "gem install bundler --no-ri --no-rdoc"
 RUN /bin/bash -l -c "gem install site-inspector -v 1.0.2 --no-ri --no-rdoc"
 
 ###
-# Go
-
-ENV GOLANG_VERSION 1.3.3
-
-RUN curl -sSL https://golang.org/dl/go${GOLANG_VERSION}.src.tar.gz \
-    | tar -v -C /usr/src -xz
-
-RUN cd /usr/src/go/src \
-      && ./make.bash --no-clean 2>&1
-
-ENV PATH /usr/src/go/bin:$PATH
-ENV GOPATH /go
-ENV PATH /go/bin:$PATH
-
-###
 # Node
 RUN ln -s /usr/bin/nodejs /usr/bin/node
 
 ###
 # Installation
 ###
-
-###
-# ssllabs-scan
-
-RUN mkdir -p /go/src /go/bin \
-      && chmod -R 777 /go
-RUN go get github.com/ssllabs/ssllabs-scan
-ENV SSLLABS_PATH /go/bin/ssllabs-scan
 
 ###
 # phantomas

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The individual scanners each require their own dependencies. You only need to ha
 * `inspect` scanner: **Ruby** and **[site-inspector](https://github.com/benbalter/site-inspector)**, version **1.0.2 only**.
 * `tls` scanner: **Docker** (runs **[ssllabs-scan](https://github.com/ssllabs/ssllabs-scan)**).
 * `sslyze` scanner: **Docker** (runs **[sslyze](https://github.com/nabla-c0d3/sslyze)**).
-* `pageload` scanner: **Node** and **[phantomas](https://www.npmjs.com/package/phantomas)**, installed through npm.
+* `pageload` scanner: **Docker** (run **[phantomas](https://www.npmjs.com/package/phantomas)**).
 
 ##### Setting tool paths
 

--- a/README.md
+++ b/README.md
@@ -10,36 +10,18 @@ Can be used with any domain, or CSV where domains are the first column, such as 
 
 The requirements here can be quite diverse, because this tool is just a coordinator for other tools. Communication between tools is handled via CLI and STDOUT.
 
-The overall tool requires **Python 3**. To install dependencies:
+The overall tool requires **Python 3** and **Docker**. To install dependencies:
 
 ```bash
 pip install -r requirements.txt
 ```
 
-The individual scanners each require their own dependencies. You only need to have the dependencies installed for the scanners you plan to use.
+### Scanners
 
-* `inspect` scanner: **Ruby** and **[site-inspector](https://github.com/benbalter/site-inspector)**, version **1.0.2 only**.
-* `tls` scanner: **Docker** (runs **[ssllabs-scan](https://github.com/ssllabs/ssllabs-scan)**).
-* `sslyze` scanner: **Docker** (runs **[sslyze](https://github.com/nabla-c0d3/sslyze)**).
-* `pageload` scanner: **Docker** (run **[phantomas](https://www.npmjs.com/package/phantomas)**).
-
-##### Setting tool paths
-
-By default, domain-scan will expect the paths to any executables to be on the system PATH.
-
-If you need to point it to a local directory instead, you'll need to set environment variables to override this.
-
-You can set environment variables in a variety of ways -- this tool's developers use [`autoenv`](https://github.com/kennethreitz/autoenv) to manage environment variables with a `.env` file.
-
-However you set them:
-
-* Override the path to the `site-inspector` executable by setting the `SITE_INSPECTOR_PATH` environment variable.
-
-* Override the path to the `ssllabs-scan` executable by setting the `SSLLABS_PATH` environment variable.
-
-* Override the path to the `sslyze.py` executable by setting the `SSLYZE_PATH` environment variable. An env var of `PYENV_VERSION=2.7.9` is passed by default, override version with `SSLYZE_PYENV`.
-
-* Override the path to the `phantomas` executable by setting the `PHANTOMAS_PATH` environment variable.
+* `inspect` scanner: runs **[site-inspector](https://github.com/benbalter/site-inspector)**
+* `tls` scanner: runs **[ssllabs-scan](https://github.com/ssllabs/ssllabs-scan)**
+* `sslyze` scanner: runs **[sslyze](https://github.com/nabla-c0d3/sslyze)**
+* `pageload` scanner: runs **[phantomas](https://www.npmjs.com/package/phantomas)**
 
 ### Usage
 

--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ pip install -r requirements.txt
 The individual scanners each require their own dependencies. You only need to have the dependencies installed for the scanners you plan to use.
 
 * `inspect` scanner: **Ruby** and **[site-inspector](https://github.com/benbalter/site-inspector)**, version **1.0.2 only**.
-* `tls` scanner: **Go** and **[ssllabs-scan](https://github.com/ssllabs/ssllabs-scan)**, stable branch.
-* `sslyze` scanner: **Python 2** and **[sslyze](https://github.com/nabla-c0d3/sslyze)**, downloaded from [their latest compiled release](https://github.com/nabla-c0d3/sslyze/releases).
+* `tls` scanner: **Docker** (runs **[ssllabs-scan](https://github.com/ssllabs/ssllabs-scan)**).
+* `sslyze` scanner: **Docker** (runs **[sslyze](https://github.com/nabla-c0d3/sslyze)**).
 * `pageload` scanner: **Node** and **[phantomas](https://www.npmjs.com/package/phantomas)**, installed through npm.
 
 ##### Setting tool paths

--- a/README.md
+++ b/README.md
@@ -120,7 +120,6 @@ Some high-priority TODOs here:
 
 * **JSON output**. Refactor scanners to return a dict instead of a row. Have scanners specify both JSON-style field headers *and* CSV-style column headers in a 2-dimensional array. Use this to make it so JSON and CSV can both be serialized with appropriate fields and in the right order. Include JSON results in the `results/` dir.
 * **Handle network loss gracefully.** Right now, the scanner will assume that a domain is "down" if the network is down, and cache that. That makes trusting the results of a batch run iffy. I don't know the best way to distinguish between a domain being unreachable, and the network *making* the domain unreachable.
-* **Upgrade to site-inspector 3.x.** This repo depends on site-inspector 1.0.2, which is behind the times. But, site-inspector 3 needs more testing and work first. site-inspector 2 also is not backwards-compatible, in CLI syntax or in result format.
 
 ### Public domain
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,3 +2,5 @@ scan:
   build: .
   volumes:
   - ./:/home/scanner
+  # https://jpetazzo.github.io/2015/09/03/do-not-use-docker-in-docker-for-ci/
+  - /var/run/docker.sock:/var/run/docker.sock

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-ipython
 requests
 strict-rfc3339
 

--- a/scan_wrap.sh
+++ b/scan_wrap.sh
@@ -1,10 +1,6 @@
 #!/bin/bash
 set -e
 
-# Rather not worry about the intersection of RVM, ENTRYPOINT and profile
-# sourcing. This just works.
-. /usr/local/rvm/scripts/rvm
-
 # Run the scan with passthrough arguments.
 case $1 in
   drop  )

--- a/scanners/pageload.py
+++ b/scanners/pageload.py
@@ -12,7 +12,6 @@ import os
 # previously detected "canonical" endpoint for a domain.
 ##
 
-command = os.environ.get("PHANTOMAS_PATH", "phantomas")
 init = None
 
 # Since these are finely time-sensitive metrics, I think we want
@@ -61,8 +60,9 @@ def scan(domain, options):
 
     # If no cache, or we should run anyway, do the scan.
     else:
-        logging.debug("\t %s %s --reporter=json --ignore-ssl-errors" % (command, url))
-        raw = utils.scan([command, url, "--reporter=json", "--ignore-ssl-errors"])
+        command = ["docker", "run", "18fgsa/phantomas", url, "--reporter=json", "--ignore-ssl-errors"]
+        logging.debug("\t %s" % " ".join(command))
+        raw = utils.scan(command)
         if not raw:
             utils.write(utils.invalid({}), cache)
             return None

--- a/scanners/sslyze.py
+++ b/scanners/sslyze.py
@@ -12,15 +12,7 @@ import dateutil.parser
 #
 # If data exists for a domain from `inspect`, will check results
 # and only process domains with valid HTTPS, or broken chains.
-#
-# Currently depends on pyenv to manage calling out to Python2 from Python3.
 ###
-
-command = os.environ.get("SSLYZE_PATH", "sslyze_cli.py")
-
-# Kind of a hack for now, other methods of running sslyze with Python 2 welcome
-pyenv_version = os.environ.get("SSLYZE_PYENV", "2.7.11")
-
 
 def scan(domain, options):
     logging.debug("[%s][sslyze]" % domain)
@@ -51,23 +43,13 @@ def scan(domain, options):
         xml = open(cache_xml).read()
 
     else:
-        logging.debug("\t %s %s" % (command, domain))
+        logging.debug("\t %s %s" % ("docker sslyze", domain))
         # use scan_domain (possibly www-prefixed) to do actual scan
 
-        # Give the Python shell environment a pyenv environment.
-        pyenv_init = "eval \"$(pyenv init -)\" && pyenv shell %s" % pyenv_version
-        # Really un-ideal, but calling out to Python2 from Python 3 is a nightmare.
-        # I don't think this tool's threat model includes untrusted CSV, either.
-        raw = utils.unsafe_execute("%s && %s --regular --quiet %s --xml_out=%s" % (pyenv_init, command, scan_domain, cache_xml))
-
-        if raw is None:
+        xml = utils.scan(["docker", "run", "18fgsa/sslyze", "--regular", "--quiet", scan_domain, "--xml_out=-"])
+        if xml is None:
             # TODO: save standard invalid XML data...?
             logging.warn("\tBad news scanning, sorry!")
-            return None
-
-        xml = utils.scan(["cat", cache_xml])
-        if not xml:
-            logging.warn("\tBad news reading XML, sorry!")
             return None
 
         utils.write(xml, cache_xml)

--- a/scanners/sslyze.py
+++ b/scanners/sslyze.py
@@ -14,6 +14,7 @@ import dateutil.parser
 # and only process domains with valid HTTPS, or broken chains.
 ###
 
+
 def scan(domain, options):
     logging.debug("[%s][sslyze]" % domain)
 
@@ -43,7 +44,7 @@ def scan(domain, options):
         xml = open(cache_xml).read()
 
     else:
-        logging.debug("\t %s %s" % ("docker sslyze", domain))
+        logging.debug("\t %s %s" % ("docker run sslyze", domain))
         # use scan_domain (possibly www-prefixed) to do actual scan
 
         xml = utils.scan(["docker", "run", "18fgsa/sslyze", "--regular", "--quiet", scan_domain, "--xml_out=-"])

--- a/scanners/tls.py
+++ b/scanners/tls.py
@@ -13,7 +13,6 @@ import os
 # and only process domains with valid HTTPS, or broken chains.
 ###
 
-command = os.environ.get("SSLLABS_PATH", "ssllabs-scan")
 workers = 1
 
 
@@ -40,16 +39,16 @@ def scan(domain, options):
             if data.get('invalid'):
                 return None
         else:
-            logging.debug("\t %s %s" % (command, domain))
+            logging.debug("\t %s %s" % ("docker run ssllabs", domain))
 
             usecache = str(not force).lower()
 
             if options.get("debug"):
-                cmd = [command, "--usecache=%s" % usecache,
-                       "--verbosity=debug", domain]
+                cmd = ["docker", "run", "jumanjiman/ssllabs-scan",
+                       "--usecache=%s" % usecache, "--verbosity=debug", domain]
             else:
-                cmd = [command, "--usecache=%s" % usecache,
-                       "--quiet", domain]
+                cmd = ["docker", "run", "jumanjiman/ssllabs-scan",
+                       "--usecache=%s" % usecache, "--quiet", domain]
             raw = utils.scan(cmd)
             if raw:
                 data = json.loads(raw)


### PR DESCRIPTION
This pull request switches `ssllabs-scan` and `sslyze` to run in their own Docker containers, rather than in the top-level domain-scan container. Quite happy with how many dependencies this was able to remove from the Dockerfile!

@adelevie Let me know what you think! I'm pretty new to domain-scan, so also please try this locally to make sure it still works as expected.

/cc #66 
