### PR TITLE
Unpin apt dependencies in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,38 +17,38 @@ RUN \
         --yes \
         --no-install-recommends \
         --no-install-suggests \
-      build-essential=11.6ubuntu6 \
-      curl=7.35.0-1ubuntu2.6 \
+      build-essential \
+      curl \
       git \
       libc6-dev \
-      libfontconfig1=2.11.0-0ubuntu4.1 \
-      libreadline-dev=6.3-4ubuntu2 \
+      libfontconfig1 \
+      libreadline-dev \
       libssl-dev \
       libssl-doc \
       libxml2-dev \
-      libxslt1-dev=1.1.28-2build1 \
-      libyaml-dev=0.1.4-3ubuntu3.1 \
-      make=3.81-8.2ubuntu3 \
-      nodejs=0.10.25~dfsg2-2ubuntu1 \
-      npm=1.3.10~dfsg-1 \
-      python3-dev=3.4.0-0ubuntu2 \
-      python3-pip=1.5.4-1ubuntu3 \
-      unzip=6.0-9ubuntu1.5 \
-      wget=1.15-1ubuntu1.14.04.1 \
-      zlib1g-dev=1:1.2.8.dfsg-1ubuntu1 \
+      libxslt1-dev \
+      libyaml-dev \
+      make \
+      nodejs \
+      npm \
+      python3-dev \
+      python3-pip \
+      unzip \
+      wget \
+      zlib1g-dev \
 
       # Preemptively install these so we don't have to clean up after RVM.
-      autoconf=2.69-6 \
-      automake=1:1.14.1-2ubuntu1 \
-      bison=2:3.0.2.dfsg-2 \
-      gawk=1:4.0.1+dfsg-2.1ubuntu2 \
-      libffi-dev=3.1~rc1+r3.0.13-12ubuntu0.1 \
-      libgdbm-dev=1.8.3-12build1 \
-      libncurses5-dev=5.9+20140118-1ubuntu1 \
-      libsqlite3-dev=3.8.2-1ubuntu2.1 \
-      libtool=2.4.2-1.7ubuntu1 \
-      pkg-config=0.26-1ubuntu4 \
-      sqlite3=3.8.2-1ubuntu2.1 \
+      autoconf \
+      automake \
+      bison \
+      gawk \
+      libffi-dev \
+      libgdbm-dev \
+      libncurses5-dev \
+      libsqlite3-dev \
+      libtool \
+      pkg-config \
+      sqlite3 \
 
       # Additional dependencies for python-build
       libbz2-dev \


### PR DESCRIPTION
I just returned to working with domain-scan and was frustrated to experience immediate breakage upon running `docker-compose build`:

```
$ docker-compose build
Building scan
Step 1 : FROM ubuntu:14.04.4
14.04.4: Pulling from library/ubuntu
56eb14001ceb: Pull complete
7ff49c327d83: Pull complete
6e532f87f96d: Pull complete
3ce63537e70c: Pull complete
Digest: sha256:d67ef8e385f1c8b13d8c3e7622dc31b51d07e5623c1d034ebe2acb14a11fb30d
Status: Downloaded newer image for ubuntu:14.04.4
 ---> 38c759202e30
Step 2 : MAINTAINER V. David Zvenyach <vladlen.zvenyach@gsa.gov>
 ---> Running in 2d029c666908
 ---> 7914586cdc21
Removing intermediate container 2d029c666908
Step 3 : RUN apt-get update         -qq     && apt-get install         -qq         --yes         --no-install-recommends         --no-install-suggests       build-essential=11.6ubuntu6       curl=7.35.0-1ubuntu2.6       git       libc6-dev       libfontconfig1=2.11.0-0ubuntu4.1       libreadline-dev=6.3-4ubuntu2       libssl-dev       libssl-doc       libxml2-dev       libxslt1-dev=1.1.28-2build1       libyaml-dev=0.1.4-3ubuntu3.1       make=3.81-8.2ubuntu3       nodejs=0.10.25~dfsg2-2ubuntu1       npm=1.3.10~dfsg-1       python3-dev=3.4.0-0ubuntu2       python3-pip=1.5.4-1ubuntu3       unzip=6.0-9ubuntu1.5       wget=1.15-1ubuntu1.14.04.1       zlib1g-dev=1:1.2.8.dfsg-1ubuntu1       autoconf=2.69-6       automake=1:1.14.1-2ubuntu1       bison=2:3.0.2.dfsg-2       gawk=1:4.0.1+dfsg-2.1ubuntu2       libffi-dev=3.1~rc1+r3.0.13-12ubuntu0.1       libgdbm-dev=1.8.3-12build1       libncurses5-dev=5.9+20140118-1ubuntu1       libsqlite3-dev=3.8.2-1ubuntu2.1       libtool=2.4.2-1.7ubuntu1       pkg-config=0.26-1ubuntu4       sqlite3=3.8.2-1ubuntu2.1       libbz2-dev       llvm       libncursesw5-dev     && apt-get clean     && rm -rf /var/lib/apt/lists/*
 ---> Running in 7db782d01d2c
E: Version '1.15-1ubuntu1.14.04.1' for 'wget' was not found
ERROR: Service 'scan' failed to build: The command '/bin/sh -c apt-get update         -qq     && apt-get install         -qq         --yes         --no-install-recommends         --no-install-suggests       build-essential=11.6ubuntu6       curl=7.35.0-1ubuntu2.6       git       libc6-dev       libfontconfig1=2.11.0-0ubuntu4.1       libreadline-dev=6.3-4ubuntu2       libssl-dev       libssl-doc       libxml2-dev       libxslt1-dev=1.1.28-2build1       libyaml-dev=0.1.4-3ubuntu3.1       make=3.81-8.2ubuntu3       nodejs=0.10.25~dfsg2-2ubuntu1       npm=1.3.10~dfsg-1       python3-dev=3.4.0-0ubuntu2       python3-pip=1.5.4-1ubuntu3       unzip=6.0-9ubuntu1.5       wget=1.15-1ubuntu1.14.04.1       zlib1g-dev=1:1.2.8.dfsg-1ubuntu1       autoconf=2.69-6       automake=1:1.14.1-2ubuntu1       bison=2:3.0.2.dfsg-2       gawk=1:4.0.1+dfsg-2.1ubuntu2       libffi-dev=3.1~rc1+r3.0.13-12ubuntu0.1       libgdbm-dev=1.8.3-12build1       libncurses5-dev=5.9+20140118-1ubuntu1       libsqlite3-dev=3.8.2-1ubuntu2.1       libtool=2.4.2-1.7ubuntu1       pkg-config=0.26-1ubuntu4       sqlite3=3.8.2-1ubuntu2.1       libbz2-dev       llvm       libncursesw5-dev     && apt-get clean     && rm -rf /var/lib/apt/lists/*' returned a non-zero code: 100
```

This is especially frustrating since I encountered and had to fix a similar issue 3 weeks ago, in #68.

Pinning the versions of the apt dependencies in the Dockerfile causes periodic breakage of `docker-compose build` as the packages get updated. Since we are using a stable release of a long term service distribution of Linux, it should be safe to rely on the distribution's maintainers to keep packages stable and compatible with each other; therefore, pinning the apt dependneices is unnecessary, and unpinning them prevents periodic and annoying breakage.