### PR TITLE
Adds caching for the preload list itself, override with --force

### DIFF
--- a/scanners/subdomains.py
+++ b/scanners/subdomains.py
@@ -141,10 +141,10 @@ def scan(domain, options):
         return None
 
     # bad hostname for cert?
-    if (protocol == "https") and (endpoint.get("https_bad_name", False) is True):
-        bad_cert_name = True  # nopep8
-    else:
-        bad_cert_name = False  # nopep8
+    # if (protocol == "https") and (endpoint.get("https_bad_name", False) is True):
+    #     bad_cert_name = True  # nopep8
+    # else:
+    #     bad_cert_name = False  # nopep8
 
     # If the subdomain redirects anywhere, see if it redirects within the domain
     if endpoint.get("redirect_to"):

--- a/scanners/utils.py
+++ b/scanners/utils.py
@@ -167,6 +167,7 @@ def unsafe_execute(command):
 def cache_path(domain, operation, ext="json"):
     return os.path.join(cache_dir(), operation, ("%s.%s" % (domain, ext)))
 
+
 # cache a single one-off file, not associated with a domain or operation
 def cache_single(filename):
     return os.path.join(cache_dir(), filename)

--- a/scanners/utils.py
+++ b/scanners/utils.py
@@ -167,6 +167,10 @@ def unsafe_execute(command):
 def cache_path(domain, operation, ext="json"):
     return os.path.join(cache_dir(), operation, ("%s.%s" % (domain, ext)))
 
+# cache a single one-off file, not associated with a domain or operation
+def cache_single(filename):
+    return os.path.join(cache_dir(), filename)
+
 
 # Used to quickly get cached data for a domain.
 def data_for(domain, operation):


### PR DESCRIPTION
This will cache the preload list when downloaded, so it doesn't run every time. Not a big deal during production scans, but very helpful in development and testing.