### PR TITLE
Begins a scanner for the pshtt HTTP inspection tool

### DIFF
--- a/scanners/ncats.py
+++ b/scanners/ncats.py
@@ -1,0 +1,74 @@
+import logging
+from scanners import utils
+import os
+import json
+
+###
+# == ncats ==
+#
+# Inspect a site's TLS configuration using NCATS' Python site inspector.
+#
+# Currently depends on pyenv to manage calling out to Python2 from Python3.
+###
+
+command = os.environ.get("NCATS_PATH", "site_inspector_cli")
+
+# Kind of a hack for now, other methods of running sslyze with Python 2 welcome
+pyenv_version = os.environ.get("NCATS_PYENV", "2.7.11")
+
+# default to a long timeout
+timeout = 30
+
+# default to a custom user agent, can be overridden
+user_agent = os.environ.get("NCATS_USER_AGENT", "github.com/18f/domain-scan, ncats.py")
+
+# save (and look for) preload file in cache/preload-list.json
+# same format as inspect.py uses
+preload_cache = utils.cache_single("preload-list.json")
+
+def scan(domain, options):
+    logging.debug("[%s][ncats]" % domain)
+
+    # cache output from ncats
+    cache_ncats = utils.cache_path(domain, "ncats", ext="json")
+
+    force = options.get("force", False)
+    data = None
+
+    if (force is False) and (os.path.exists(cache_ncats)):
+        logging.debug("\tCached.")
+        raw = open(cache_ncats).read()
+        data = json.loads(raw)
+
+    else:
+        logging.debug("\t %s %s" % (command, domain))
+
+        # Give the Python shell environment a pyenv environment.
+        pyenv_init = "eval \"$(pyenv init -)\" && pyenv shell %s" % pyenv_version
+        # Really un-ideal, but calling out to Python2 from Python 3 is a nightmare.
+        # I don't think this tool's threat model includes untrusted CSV, either.
+        raw = utils.unsafe_execute("%s && %s %s --json --user-agent %s --timeout %i --preload-cache %s" % (pyenv_init, command, domain, user_agent, timeout, preload_cache))
+
+        if raw is None:
+            # TODO: save invalid data...?
+            logging.warn("\tBad news scanning, sorry!")
+            return None
+
+        data = json.loads(raw)
+        utils.write(utils.json_for(data), utils.cache_path(domain, "ncats"))
+
+    row = []
+    for field in headers:
+        row.append(data[field])
+
+    yield row
+
+headers = [
+    "Domain", "Live", "Redirect",
+    "Valid HTTPS", "Defaults HTTPS", "Downgrades HTTPS",
+    "Strictly Forces HTTPS", "HTTPS Bad Chain", "HTTPS Bad Host Name",
+    "Expired Cert", "Weak Signature Chain", "HSTS", "HSTS Header",
+    "HSTS Max Age", "HSTS All Subdomains", "HSTS Preload",
+    "HSTS Preload Ready", "HSTS Preloaded",
+    "Broken Root", "Broken WWW"
+]

--- a/scanners/pshtt.py
+++ b/scanners/pshtt.py
@@ -72,8 +72,10 @@ def scan(domain, options):
         value = data[field]
 
         # TODO: Fix this upstream
-        if value is None:
-            value = False
+        if (field != "HSTS Header") and (field != "Redirect To"):
+            if value is None:
+                value = False
+
         row.append(value)
 
     yield row

--- a/scanners/pshtt.py
+++ b/scanners/pshtt.py
@@ -39,6 +39,8 @@ def scan(domain, options):
         logging.debug("\tCached.")
         raw = open(cache_pshtt).read()
         data = json.loads(raw)
+        if (data.__class__ is dict) and data.get('invalid'):
+            return None
 
     else:
         logging.debug("\t %s %s" % (command, domain))
@@ -54,8 +56,8 @@ def scan(domain, options):
         # I don't think this tool's threat model includes untrusted CSV, either.
         raw = utils.unsafe_execute("%s && %s %s %s" % (pyenv_init, command, domain, flags))
 
-        if raw is None:
-            # TODO: save invalid data...?
+        if not raw:
+            utils.write(utils.invalid({}), cache_pshtt)
             logging.warn("\tBad news scanning, sorry!")
             return None
 
@@ -72,11 +74,9 @@ def scan(domain, options):
     yield row
 
 headers = [
-    "Live", "Redirect",
-    "Valid HTTPS", "Defaults HTTPS", "Downgrades HTTPS",
-    "Strictly Forces HTTPS", "HTTPS Bad Chain", "HTTPS Bad Host Name",
-    "Expired Cert", "Weak Signature Chain", "HSTS", "HSTS Header",
-    "HSTS Max Age", "HSTS All Subdomains", "HSTS Preload",
-    "HSTS Preload Ready", "HSTS Preloaded",
-    "Broken Root", "Broken WWW"
+    "Canonical URL", "Live", "Redirect",
+    "Valid HTTPS", "Defaults HTTPS", "Downgrades HTTPS", "Strictly Forces HTTPS",
+    "HTTPS Bad Chain", "HTTPS Bad Host Name", "HTTPS Expired Cert",
+    "HSTS", "HSTS Header", "HSTS Max Age", "HSTS Entire Domain",
+    "HSTS Preload Ready", "HSTS Preloaded"
 ]

--- a/scanners/pshtt.py
+++ b/scanners/pshtt.py
@@ -4,40 +4,40 @@ import os
 import json
 
 ###
-# == ncats ==
+# == pshtt ==
 #
-# Inspect a site's TLS configuration using NCATS' Python site inspector.
+# Inspect a site's TLS configuration using DHS NCATS' pshtt tool.
 #
 # Currently depends on pyenv to manage calling out to Python2 from Python3.
 ###
 
-command = os.environ.get("NCATS_PATH", "site_inspector_cli")
+command = os.environ.get("PSHTT_PATH", "pshtt_cli")
 
 # Kind of a hack for now, other methods of running sslyze with Python 2 welcome
-pyenv_version = os.environ.get("NCATS_PYENV", "2.7.11")
+pyenv_version = os.environ.get("PSHTT_PYENV", "2.7.11")
 
 # default to a long timeout
 timeout = 30
 
 # default to a custom user agent, can be overridden
-user_agent = os.environ.get("NCATS_USER_AGENT", "github.com/18f/domain-scan, ncats.py")
+user_agent = os.environ.get("PSHTT_USER_AGENT", "github.com/18f/domain-scan, pshtt.py")
 
 # save (and look for) preload file in cache/preload-list.json
 # same format as inspect.py uses
 preload_cache = utils.cache_single("preload-list.json")
 
 def scan(domain, options):
-    logging.debug("[%s][ncats]" % domain)
+    logging.debug("[%s][pshtt]" % domain)
 
-    # cache output from ncats
-    cache_ncats = utils.cache_path(domain, "ncats", ext="json")
+    # cache output from pshtt
+    cache_pshtt = utils.cache_path(domain, "pshtt", ext="json")
 
     force = options.get("force", False)
     data = None
 
-    if (force is False) and (os.path.exists(cache_ncats)):
+    if (force is False) and (os.path.exists(cache_pshtt)):
         logging.debug("\tCached.")
-        raw = open(cache_ncats).read()
+        raw = open(cache_pshtt).read()
         data = json.loads(raw)
 
     else:
@@ -60,9 +60,9 @@ def scan(domain, options):
             return None
 
         data = json.loads(raw)
-        utils.write(utils.json_for(data), utils.cache_path(domain, "ncats"))
+        utils.write(utils.json_for(data), utils.cache_path(domain, "pshtt"))
 
-    # NCATS scanner uses JSON arrays, even for single items
+    # pshtt scanner uses JSON arrays, even for single items
     data = data[0]
 
     row = []

--- a/scanners/pshtt.py
+++ b/scanners/pshtt.py
@@ -69,13 +69,18 @@ def scan(domain, options):
 
     row = []
     for field in headers:
-        row.append(data[field])
+        value = data[field]
+
+        # TODO: Fix this upstream
+        if value is None:
+            value = False
+        row.append(value)
 
     yield row
 
 headers = [
-    "Canonical URL", "Live", "Redirect",
-    "Valid HTTPS", "Defaults HTTPS", "Downgrades HTTPS", "Strictly Forces HTTPS",
+    "Canonical URL", "Live", "Redirect", "Redirect To",
+    "Valid HTTPS", "Defaults to HTTPS", "Downgrades HTTPS", "Strictly Forces HTTPS",
     "HTTPS Bad Chain", "HTTPS Bad Host Name", "HTTPS Expired Cert",
     "HSTS", "HSTS Header", "HSTS Max Age", "HSTS Entire Domain",
     "HSTS Preload Ready", "HSTS Preloaded"

--- a/scanners/utils.py
+++ b/scanners/utils.py
@@ -64,7 +64,7 @@ def configure_logging(options=None):
 
 
 # mkdir -p in python, from:
-# http://stackoverflow.com/questions/600268/mkdir-p-functionality-in-python
+# https://stackoverflow.com/questions/600268/mkdir-p-functionality-in-python
 def mkdir_p(path):
     try:
         os.makedirs(path)
@@ -202,9 +202,8 @@ def utc_timestamp():
 def base_domain_for(subdomain):
     return str.join(".", subdomain.split(".")[-2:])
 
+
 # Load the first column of a CSV into memory as an array of strings.
-
-
 def load_domains(domain_csv, whole_rows=False):
     domains = []
     with open(domain_csv, newline='') as csvfile:


### PR DESCRIPTION
This creates a scanner that integrates with [`pshtt`](https://github.com/dhs-ncats/pshtt), a Python-based tool. `pshtt` is designed as a single-purpose replacement for the HTTP inspection tool, currently provided via an unmaintained branch of [`site-inspector`](https://github.com/benbalter/site-inspector/tree/erics-mode)) and integrated into domain-scan as the `inspect` scanner.

`pshtt` is a new tool, and is not yet at feature parity with `site-inspector` and the code still needs some more work and refactoring. It outputs a CSV very similar to `inspect.csv`, though the results currently use different logic and it will not reliably give the same results as the `inspect` scanner.

In addition, `pshtt` currently integrates with `sslyze` and requires Python 2, though I would like to see if the use of `sslyze` can be replaced, and if it can be made agnostic to Python 2 or 3. That said, `sslyze` is going to be used somewhere in this tool chain (there's already an `sslyze` scanner in this project), which will require communication between Python 3 and Python 2. It would be useful to figure out what the Right Way is to handle that, because I'm pretty sure that prepending some `pyenv` commands to an unsafe shell execution (as we do now) is not the Right Way.

This is a WIP, but it does work with `pshtt`'s `master` branch at the time I'm filing it, so I think it's merge-ready pretty much any time. 