### PR TITLE
Fix bug to detect HTTP2 in SSL Labs result

### DIFF
--- a/scanners/tls.py
+++ b/scanners/tls.py
@@ -97,7 +97,7 @@ def scan(domain, options):
             npn = endpoint['details'].get('npnProtocols', None)
             if npn:
                 spdy = ("spdy" in npn)
-                h2 = ("h2-" in npn)
+                h2 = ("h2" in npn)
 
             yield [
                 endpoint['grade'],


### PR DESCRIPTION
I just fixed a small bug 
The  SSL Labs API returns : 
```bash
$ ./ssllabs-scan verif.site
{
    "npnProtocols": "h2 http/1.1"
}
```