### PR TITLE
Use pshtt to determine eligibility for other scanners

### DIFF
--- a/scanners/pageload.py
+++ b/scanners/pageload.py
@@ -8,7 +8,7 @@ import os
 #
 # Evaluate page laod time information using Phantomas.
 #
-# If data exists for a domain from `inspect`, will use the
+# If data exists for a domain from `pshtt`, will use the
 # previously detected "canonical" endpoint for a domain.
 ##
 
@@ -23,15 +23,13 @@ workers = 2
 def scan(domain, options):
     logging.debug("[%s][pageload]" % domain)
 
-    inspection = utils.data_for(domain, "inspect")
-
     # If we have data from inspect, skip if it's not a live domain.
-    if inspection and (not inspection.get("up")):
+    if utils.domain_not_live(domain):
         logging.debug("\tSkipping, domain not reachable during inspection.")
         return None
 
     # If we have data from inspect, skip if it's just a redirector.
-    if inspection and (inspection.get("redirect") is True):
+    if utils.domain_is_redirect(domain):
         logging.debug("\tSkipping, domain seen as just a redirector during inspection.")
         return None
 
@@ -39,8 +37,8 @@ def scan(domain, options):
     if not (domain.startswith('http://') or domain.startswith('https://')):
 
         # If we have data from inspect, use the canonical endpoint.
-        if inspection and inspection.get("canonical"):
-            url = inspection.get("canonical")
+        if utils.domain_canonical(domain):
+            url = utils.domain_canonical(domain)
 
         # Otherwise, well, whatever.
         else:

--- a/scanners/pageload.py
+++ b/scanners/pageload.py
@@ -23,12 +23,12 @@ workers = 2
 def scan(domain, options):
     logging.debug("[%s][pageload]" % domain)
 
-    # If we have data from inspect, skip if it's not a live domain.
+    # If we have data from pshtt, skip if it's not a live domain.
     if utils.domain_not_live(domain):
         logging.debug("\tSkipping, domain not reachable during inspection.")
         return None
 
-    # If we have data from inspect, skip if it's just a redirector.
+    # If we have data from pshtt, skip if it's just a redirector.
     if utils.domain_is_redirect(domain):
         logging.debug("\tSkipping, domain seen as just a redirector during inspection.")
         return None
@@ -36,7 +36,7 @@ def scan(domain, options):
     # phantomas needs a URL, not just a domain.
     if not (domain.startswith('http://') or domain.startswith('https://')):
 
-        # If we have data from inspect, use the canonical endpoint.
+        # If we have data from pshtt, use the canonical endpoint.
         if utils.domain_canonical(domain):
             url = utils.domain_canonical(domain)
 

--- a/scanners/sslyze.py
+++ b/scanners/sslyze.py
@@ -10,7 +10,7 @@ import dateutil.parser
 #
 # Inspect a site's TLS configuration using sslyze.
 #
-# If data exists for a domain from `inspect`, will check results
+# If data exists for a domain from `pshtt`, will check results
 # and only process domains with valid HTTPS, or broken chains.
 #
 # Currently depends on pyenv to manage calling out to Python2 from Python3.
@@ -26,14 +26,13 @@ def scan(domain, options):
     logging.debug("[%s][sslyze]" % domain)
 
     # Optional: skip domains which don't support HTTPS in prior inspection
-    inspection = utils.data_for(domain, "inspect")
-    if inspection and (not inspection.get("support_https")):
+    if utils.domain_doesnt_support_https(domain):
         logging.debug("\tSkipping, HTTPS not supported in inspection.")
         return None
 
     # Optional: if inspect data says canonical endpoint uses www and this domain
     # doesn't have it, add it.
-    if inspection and (inspection.get("canonical_endpoint") == "www") and (not domain.startswith("www.")):
+    if utils.domain_uses_www(domain):
         scan_domain = "www.%s" % domain
     else:
         scan_domain = domain
@@ -51,7 +50,7 @@ def scan(domain, options):
         xml = open(cache_xml).read()
 
     else:
-        logging.debug("\t %s %s" % (command, domain))
+        logging.debug("\t %s %s" % (command, scan_domain))
         # use scan_domain (possibly www-prefixed) to do actual scan
 
         # Give the Python shell environment a pyenv environment.

--- a/scanners/sslyze.py
+++ b/scanners/sslyze.py
@@ -30,7 +30,7 @@ def scan(domain, options):
         logging.debug("\tSkipping, HTTPS not supported in inspection.")
         return None
 
-    # Optional: if inspect data says canonical endpoint uses www and this domain
+    # Optional: if pshtt data says canonical endpoint uses www and this domain
     # doesn't have it, add it.
     if utils.domain_uses_www(domain):
         scan_domain = "www.%s" % domain

--- a/scanners/tls.py
+++ b/scanners/tls.py
@@ -9,7 +9,7 @@ import os
 #
 # Inspect a site's valid TLS configuration using ssllabs-scan.
 #
-# If data exists for a domain from `inspect`, will check results
+# If data exists for a domain from `pshtt`, will check results
 # and only process domains with valid HTTPS, or broken chains.
 ###
 
@@ -21,8 +21,7 @@ def scan(domain, options):
     logging.debug("[%s][tls]" % domain)
 
     # If inspection data exists, check to see if we can skip.
-    inspection = utils.data_for(domain, "inspect")
-    if inspection and (not inspection.get("support_https")):
+    if utils.domain_doesnt_support_https(domain):
         logging.debug("\tSkipping, HTTPS not supported in inspection.")
         return None
 


### PR DESCRIPTION
Many of the scanners use cached `inspect` results, if available, to determine eligibility and save time by skipping domains, or use the results to focus their scan on the most correct endpoint. The presence of `inspect` data is optional, but can improve the result of other scanners if it's done.

This changes those scanners to use the results of the `pshtt` scanner instead of the `inspect` scanner. The one exception is the `subdomains` scanner, which is a bit non-trivial and which I'll refactor at a (near) later time.