### PR TITLE
Like sslyze, have the tls (SSL Labs) scanner use the canonical endpoint

### DIFF
--- a/scanners/tls.py
+++ b/scanners/tls.py
@@ -25,94 +25,94 @@ def scan(domain, options):
         logging.debug("\tSkipping, HTTPS not supported in inspection.")
         return None
 
+
+    # cache reformatted JSON from ssllabs
+    cache = utils.cache_path(domain, "tls")
+
+    force = options.get("force", False)
+
+    if (force is False) and (os.path.exists(cache)):
+        logging.debug("\tCached.")
+        raw = open(cache).read()
+        data = json.loads(raw)
+
+        if data.get('invalid'):
+            return None
     else:
-        # cache reformatted JSON from ssllabs
-        cache = utils.cache_path(domain, "tls")
+        logging.debug("\t %s %s" % (command, domain))
 
-        force = options.get("force", False)
+        usecache = str(not force).lower()
 
-        if (force is False) and (os.path.exists(cache)):
-            logging.debug("\tCached.")
-            raw = open(cache).read()
+        if options.get("debug"):
+            cmd = [command, "--usecache=%s" % usecache,
+                   "--verbosity=debug", domain]
+        else:
+            cmd = [command, "--usecache=%s" % usecache,
+                   "--quiet", domain]
+        raw = utils.scan(cmd)
+        if raw:
             data = json.loads(raw)
 
-            if data.get('invalid'):
+            # if SSL Labs gave us back an error response, cache this
+            # as an invalid entry.
+            if len(data) < 1:
+                utils.write(utils.invalid({'response': data}), cache)
                 return None
+
+            # we only give ssllabs-scan one at a time,
+            # so we can de-pluralize this
+            data = data[0]
+
+            # if SSL Labs had an error hitting the site, cache this
+            # as an invalid entry.
+            if data["status"] == "ERROR":
+                utils.write(utils.invalid(data), cache)
+                return None
+
+            utils.write(utils.json_for(data), cache)
         else:
-            logging.debug("\t %s %s" % (command, domain))
+            return None
+            # raise Exception("Invalid data from ssllabs-scan: %s" % raw)
 
-            usecache = str(not force).lower()
+    # can return multiple rows, one for each 'endpoint'
+    for endpoint in data['endpoints']:
 
-            if options.get("debug"):
-                cmd = [command, "--usecache=%s" % usecache,
-                       "--verbosity=debug", domain]
-            else:
-                cmd = [command, "--usecache=%s" % usecache,
-                       "--quiet", domain]
-            raw = utils.scan(cmd)
-            if raw:
-                data = json.loads(raw)
+        # this meant it couldn't connect to the endpoint
+        if not endpoint.get("grade"):
+            continue
 
-                # if SSL Labs gave us back an error response, cache this
-                # as an invalid entry.
-                if len(data) < 1:
-                    utils.write(utils.invalid({'response': data}), cache)
-                    return None
+        sslv3 = False
+        tlsv12 = False
+        for protocol in endpoint['details']['protocols']:
+            if ((protocol['name'] == "SSL") and
+                    (protocol['version'] == '3.0')):
+                sslv3 = True
+            if ((protocol['name'] == "TLS") and
+                    (protocol['version'] == '1.2')):
+                tlsv12 = True
 
-                # we only give ssllabs-scan one at a time,
-                # so we can de-pluralize this
-                data = data[0]
+        spdy = False
+        h2 = False
+        npn = endpoint['details'].get('npnProtocols', None)
+        if npn:
+            spdy = ("spdy" in npn)
+            h2 = ("h2" in npn)
 
-                # if SSL Labs had an error hitting the site, cache this
-                # as an invalid entry.
-                if data["status"] == "ERROR":
-                    utils.write(utils.invalid(data), cache)
-                    return None
-
-                utils.write(utils.json_for(data), cache)
-            else:
-                return None
-                # raise Exception("Invalid data from ssllabs-scan: %s" % raw)
-
-        # can return multiple rows, one for each 'endpoint'
-        for endpoint in data['endpoints']:
-
-            # this meant it couldn't connect to the endpoint
-            if not endpoint.get("grade"):
-                continue
-
-            sslv3 = False
-            tlsv12 = False
-            for protocol in endpoint['details']['protocols']:
-                if ((protocol['name'] == "SSL") and
-                        (protocol['version'] == '3.0')):
-                    sslv3 = True
-                if ((protocol['name'] == "TLS") and
-                        (protocol['version'] == '1.2')):
-                    tlsv12 = True
-
-            spdy = False
-            h2 = False
-            npn = endpoint['details'].get('npnProtocols', None)
-            if npn:
-                spdy = ("spdy" in npn)
-                h2 = ("h2" in npn)
-
-            yield [
-                endpoint['grade'],
-                endpoint['details']['cert']['sigAlg'],
-                endpoint['details']['key']['alg'],
-                endpoint['details']['key']['size'],
-                endpoint['details']['forwardSecrecy'],
-                endpoint['details']['ocspStapling'],
-                endpoint['details'].get('fallbackScsv', "N/A"),
-                endpoint['details']['supportsRc4'],
-                sslv3,
-                tlsv12,
-                spdy,
-                endpoint['details']['sniRequired'],
-                h2
-            ]
+        yield [
+            endpoint['grade'],
+            endpoint['details']['cert']['sigAlg'],
+            endpoint['details']['key']['alg'],
+            endpoint['details']['key']['size'],
+            endpoint['details']['forwardSecrecy'],
+            endpoint['details']['ocspStapling'],
+            endpoint['details'].get('fallbackScsv', "N/A"),
+            endpoint['details']['supportsRc4'],
+            sslv3,
+            tlsv12,
+            spdy,
+            endpoint['details']['sniRequired'],
+            h2
+        ]
 
 headers = [
     "Grade",  # unique to SSL Labs

--- a/scanners/tls.py
+++ b/scanners/tls.py
@@ -29,6 +29,14 @@ def scan(domain, options):
     # cache reformatted JSON from ssllabs
     cache = utils.cache_path(domain, "tls")
 
+    # Optional: if pshtt data says canonical endpoint uses www and this domain
+    # doesn't have it, add it.
+    if utils.domain_uses_www(domain):
+        scan_domain = "www.%s" % domain
+    else:
+        scan_domain = domain
+
+
     force = options.get("force", False)
 
     if (force is False) and (os.path.exists(cache)):
@@ -39,16 +47,17 @@ def scan(domain, options):
         if data.get('invalid'):
             return None
     else:
-        logging.debug("\t %s %s" % (command, domain))
+        logging.debug("\t %s %s" % (command, scan_domain))
 
         usecache = str(not force).lower()
 
         if options.get("debug"):
             cmd = [command, "--usecache=%s" % usecache,
-                   "--verbosity=debug", domain]
+                   "--verbosity=debug", scan_domain]
         else:
             cmd = [command, "--usecache=%s" % usecache,
-                   "--quiet", domain]
+                   "--quiet", scan_domain]
+
         raw = utils.scan(cmd)
         if raw:
             data = json.loads(raw)


### PR DESCRIPTION
At some point, SSL Labs stopped doing its own auto-detection of the canonical endpoint for a domain, and started just scanning whatever endpoint you gave it. (I don't blame them for doing that, given how annoyingly complicated it is.)

This pull request now uses our own canonical endpoint detection to feed the right endpoint to SSL Labs, so that if a site is canonically at `www.domain.gov`, then SSL Labs will scan `https://www.domain.gov` and not `https://domain.gov`.