### PR TITLE
Use the stable branch of ssllabs-scan

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -123,6 +123,9 @@ RUN ln -s /usr/bin/nodejs /usr/bin/node
 RUN mkdir -p /go/src /go/bin \
       && chmod -R 777 /go
 RUN go get github.com/ssllabs/ssllabs-scan
+RUN cd /go/src/github.com/ssllabs/ssllabs-scan/ \
+      && git checkout stable \
+      && go install
 ENV SSLLABS_PATH /go/bin/ssllabs-scan
 
 ###


### PR DESCRIPTION
Go 1.3.3 checks out the `master` branch of GitHub repositories instead of the optionally specified default branch (a GitHub specific feature?). The default branch for `sllabs-scan` is `stable`, but Go uses the `master` branch which is used by `ssllabs-scan` for development. These changes switch the `ssllabs-scan` repository to the `stable` branch and installs it.

Some background info. Last week, ssllabs made a small change to the format of its API JSON output which broke `ssllabs-scan`[[1](https://github.com/ssllabs/ssllabs-scan/issues/415)]. A fix has already been committed to the `stable` branch, but not to the `master` branch, so `domain-scan` was not receiving any output from `ssllabs-scan`.
