### PR TITLE
add pshtt to dockerfile, readme

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -151,6 +151,12 @@ RUN wget https://github.com/nabla-c0d3/sslyze/releases/download/release-${SSLYZE
   && unzip $SSLYZE_FILE -d $SSLYZE_DEST
 
 ###
+# pshtt
+
+RUN PYENV_VERSION=2.7.11 pyenv exec pip install pshtt
+ENV PSHTT_PATH /opt/pyenv/versions/2.7.11/bin/pshtt
+
+###
 # Create Unprivileged User
 ###
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ pip install -r requirements.txt
 The individual scanners each require their own dependencies. You only need to have the dependencies installed for the scanners you plan to use.
 
 * `inspect` scanner: **Ruby** and **[site-inspector](https://github.com/benbalter/site-inspector)**, version **1.0.2 only**.
+* `pshtt` scanner: **Python 2** and **[pshtt](https://github.com/dhs-ncats/pshtt)**, ideally installed with `pyenv` via `pip install pshtt`.
 * `tls` scanner: **Go** and **[ssllabs-scan](https://github.com/ssllabs/ssllabs-scan)**, stable branch.
 * `sslyze` scanner: **Python 2** and **[sslyze](https://github.com/nabla-c0d3/sslyze)**, ideally installed with `pyenv` via `pip install sslyze`.
 * `pageload` scanner: **Node** and **[phantomas](https://www.npmjs.com/package/phantomas)**, installed through npm.
@@ -78,6 +79,7 @@ Parallelization will also cause the resulting domains to be written in an unpred
 **Scanners:**
 
 * `inspect` - HTTP/HTTPS/HSTS configuration.
+* `pshtt` - HTTP/HTTPS/HSTS configuration with the python-only [`pshtt`](https://github.com/dhs-ncats/pshtt) tool.
 * `tls` - TLS configuration, using the [SSL Labs API](https://github.com/ssllabs/ssllabs-scan/blob/stable/ssllabs-api-docs.md).
 * `sslyze` - TLS configuration, using the local [`sslyze`](https://github.com/nabla-c0d3/sslyze) command line tool.
 * `analytics` - Participation in an analytics program.

--- a/scanners/pshtt.py
+++ b/scanners/pshtt.py
@@ -13,7 +13,7 @@ import json
 
 command = os.environ.get("PSHTT_PATH", "pshtt")
 
-# Kind of a hack for now, other methods of running sslyze with Python 2 welcome
+# Kind of a hack for now, other methods of running pshtt with Python 2 welcome
 pyenv_version = os.environ.get("PSHTT_PYENV", "2.7.11")
 
 # default to a long timeout


### PR DESCRIPTION
Currently it's not possible to run the full pulse pipeline with docker, because `pshtt` is missing in the `18fgsa/domain-scan` docker image.

This PR adds support for `pshtt` in the docker images and adds it to the Readme.