### PR TITLE
Allow the use of Censys export API 

### DIFF
--- a/gatherers/censys.py
+++ b/gatherers/censys.py
@@ -179,8 +179,9 @@ def export_mode(suffix, options, uid, api_key):
 
     download_file = utils.cache_path("export", "censys", ext="csv")
 
-    # Will be filled in once the job is done.
-    if options.get("force", False) and os.path.exists(download_file):
+    force = options.get("force", False)
+
+    if (force is False) and os.path.exists(download_file):
         logging.warn("Using cached download data.")
     else:
         logging.warn("Kicking off SQL query job.")

--- a/scanners/utils.py
+++ b/scanners/utils.py
@@ -6,6 +6,7 @@ import sys
 import shutil
 import traceback
 import json
+import urllib
 import csv
 import logging
 import datetime
@@ -25,6 +26,10 @@ def run(run_method, additional=None):
     except Exception as exception:
         notify(exception)
 
+# TODO: Somewhat better error handling.
+def download(url, destination):
+    filename, headers = urllib.request.urlretrieve(url, destination)
+    return filename
 
 # read options from the command line
 #   e.g. ./scan --since=2012-03-04 --debug whatever.com


### PR DESCRIPTION
This adds an `--export` flag that will cause the `censys` gatherer to use the [Censys Export API](https://censys.io/api/v1/docs/export), which is available to Censys accounts that have been marked by the Censys team as verified researchers.

Using the SQL Export API (powered by BigQuery) is a much more thorough way to get hostname data from certificates than the search API (powered by ElasticSearch), since ElasticSearch has a maximum record limit it's willing to return for queries. This limitation is discussed at https://github.com/Censys/censys-python/issues/14, when @h-m-f-t and I discovered our Censys API pagination was topping out way before the expected end of results.

The SQL Export API is also much quicker than the paginated search API anyway! You get a full data dump in about a minute. A query initiates a job, which is then put into Censys' backend queue, and it returns a job ID to the domain-scan process. The domain-scan process polls the Censys API to see the status of that job. When the job is complete, a URL to the completed CSV is made available. The domain-scan process downloads the completed CSV, and then reads in the full hostname data from the CSV. (This CSV is cached by default.)

Because we use `urllib.request.urlretrieve` to download the CSV, and then the built in `csv` reader to read it line by line, the process _should_ avoid ever loading the entire file into memory. (However, the _unique_ hostnames among them will all get stored in memory along the way, which in general seems to be ~1/8 the size of the Censys-returned data.)

The `--export` mode has 3 relevant arguments:

* `--export`: Enables export mode.
* `--timeout`: Sets timeout before we give up on the Censys job being complete. Defaults to 20 minutes.
* `--force`: Ignore any previously cached data. Necessary if you're running this on a regular basis without varying the `--output` directory.