### PR TITLE
Adds a timeout to the pa11y scan

### DIFF
--- a/scanners/a11y.py
+++ b/scanners/a11y.py
@@ -104,7 +104,7 @@ def cache_errors(errors, domain, cache):
 def get_errors_from_pa11y_without_lambda(domain, cache):
     logging.debug("[%s][a11y]" % domain)
     pa11y = os.environ.get("PA11Y_PATH", "pa11y")
-    command = [pa11y, domain, "--reporter", "json", "--config", "pa11y_config.json", "--level", "none"]
+    command = [pa11y, domain, "--reporter", "json", "--config", "pa11y_config.json", "--level", "none", "--timeout", "300000"]
     raw = utils.scan(command)
     if raw:
         results = json.loads(raw)


### PR DESCRIPTION
Some sites are taking >30 minutes, potentially even several hours. This
is untenable, and for now we should just pass over them.