### PR TITLE
Update to sslyze 1.X

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -138,20 +138,6 @@ RUN npm install \
     phantomas
 
 ###
-# sslyze
-
-ENV SSLYZE_VERSION 0.11.0
-ENV SSLYZE_FILE sslyze-0_11-linux64.zip
-ENV SSLYZE_DEST /opt
-
-# Would be nice if bash string manipulation worked in ENV as this could use:
-# ${SSLYZE_FILE%.*}
-ENV SSLYZE_PATH ${SSLYZE_DEST}/sslyze-0_11-linux64/sslyze/sslyze.py
-RUN wget https://github.com/nabla-c0d3/sslyze/releases/download/${SSLYZE_VERSION}/${SSLYZE_FILE} \
-      --no-verbose \
-  && unzip $SSLYZE_FILE -d $SSLYZE_DEST
-
-###
 # pshtt
 
 RUN PYENV_VERSION=2.7.11 pyenv exec pip install pshtt

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The individual scanners each require their own dependencies. You only need to ha
 
 * `pshtt` scanner: **Python 2** and **[pshtt](https://github.com/dhs-ncats/pshtt)**, ideally installed with `pyenv` via `pip install pshtt`.
 * `tls` scanner: **Go** and **[ssllabs-scan](https://github.com/ssllabs/ssllabs-scan)**, stable branch.
-* `sslyze` scanner: **Python 2** and **[sslyze](https://github.com/nabla-c0d3/sslyze)**, ideally installed with `pyenv` via `pip install sslyze`.
+* `sslyze` scanner: **[sslyze](https://github.com/nabla-c0d3/sslyze)** 1.0 or greater (installed automatically via `requirements.txt`).
 * `pageload` scanner: **Node** and **[phantomas](https://www.npmjs.com/package/phantomas)**, installed through npm.
 
 ##### Setting tool paths
@@ -37,8 +37,6 @@ You can set environment variables in a variety of ways -- this tool's developers
 However you set them:
 
 * Override the path to the `ssllabs-scan` executable by setting the `SSLLABS_PATH` environment variable.
-
-* Override the path to the `sslyze.py` executable by setting the `SSLYZE_PATH` environment variable. An env var of `PYENV_VERSION=2.7.11` is passed by default, override version with `SSLYZE_PYENV`.
 
 * Override the path to the `phantomas` executable by setting the `PHANTOMAS_PATH` environment variable.
 
@@ -80,7 +78,7 @@ Parallelization will also cause the resulting domains to be written in an unpred
 
 * `pshtt` - HTTP/HTTPS/HSTS configuration with the python-only [`pshtt`](https://github.com/dhs-ncats/pshtt) tool.
 * `tls` - TLS configuration, using the [SSL Labs API](https://github.com/ssllabs/ssllabs-scan/blob/stable/ssllabs-api-docs.md).
-* `sslyze` - TLS configuration, using the local [`sslyze`](https://github.com/nabla-c0d3/sslyze) command line tool.
+* `sslyze` - TLS configuration, using [`sslyze`](https://github.com/nabla-c0d3/sslyze).
 * `analytics` - Participation in an analytics program.
 * `pageload` - Page load and rendering metrics.
 * `a11y` - Accessibility data with the [`pa11y` CLI tool](https://github.com/pa11y/pa11y) via AWS Lambda (requires an AWS account and some additional setup, described further down this document).

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,9 +3,7 @@ requests
 strict-rfc3339
 
 # to support sslyze scanner
-lxml
-BeautifulSoup4
-python-dateutil
+sslyze
 
 # to support censys gatherer
 censys

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ strict-rfc3339
 
 # to support sslyze scanner
 sslyze
+cryptography
 
 # to support censys gatherer
 censys

--- a/scanners/sslyze.py
+++ b/scanners/sslyze.py
@@ -222,9 +222,9 @@ def parse_sslyze(raw_json):
         leaf = parse_cert(served_chain[0])
         leaf_key = leaf.public_key()
 
-        if has_attr(leaf_key, "key_size"):
+        if hasattr(leaf_key, "key_size"):
             data['certs']['key_length'] = leaf_key.key_size
-        elif has_attr(leaf_key, "curve"):
+        elif hasattr(leaf_key, "curve"):
             data['certs']['key_length'] = leaf_key.curve.key_size
         else:
             data['certs']['key_length'] = None

--- a/scanners/sslyze.py
+++ b/scanners/sslyze.py
@@ -222,7 +222,12 @@ def parse_sslyze(raw_json):
         leaf = parse_cert(served_chain[0])
         leaf_key = leaf.public_key()
 
-        data['certs']['key_length'] = leaf_key.key_size
+        if has_attr(leaf_key, "key_size"):
+            data['certs']['key_length'] = leaf_key.key_size
+        elif has_attr(leaf_key, "curve"):
+            data['certs']['key_length'] = leaf_key.curve.key_size
+        else:
+            data['certs']['key_length'] = None
 
         if leaf_key.__class__ == cryptography.hazmat.backends.openssl.rsa._RSAPublicKey:
             leaf_key_type = "RSA"

--- a/scanners/sslyze.py
+++ b/scanners/sslyze.py
@@ -97,7 +97,9 @@ def scan(domain, options):
         data['config'].get('any_rc4'), data['config'].get('all_rc4'),
 
         data['certs'].get('key_type'), data['certs'].get('key_length'),
-        data['certs'].get('leaf_signature'), data['certs'].get('any_sha1'),
+        data['certs'].get('leaf_signature'),
+        data['certs'].get('any_sha1_served'),
+        data['certs'].get('any_sha1_constructed'),
         data['certs'].get('not_before'), data['certs'].get('not_after'),
         data['certs'].get('served_issuer'), data['certs'].get('constructed_issuer'),
 
@@ -113,7 +115,9 @@ headers = [
     "Any RC4", "All RC4",
 
     "Key Type", "Key Length",
-    "Signature Algorithm", "SHA-1 in Served Chain",
+    "Signature Algorithm",
+    "SHA-1 in Served Chain",
+    "SHA-1 in Constructed Chain",
     "Not Before", "Not After",
     "Highest Served Issuer", "Highest Constructed Issuer",
 
@@ -264,8 +268,15 @@ def parse_sslyze(raw_json):
         data['certs']['not_before'] = leaf.not_valid_before
         data['certs']['not_after'] = leaf.not_valid_after
 
-        # Look at only served leaf and intermediate certificates
-        data['certs']['any_sha1'] = target['certinfo']['has_sha1_in_certificate_chain']
+        any_sha1_served = False
+        for cert in served_chain:
+            if parse_cert(cert).signature_hash_algorithm.name == "sha1":
+                any_sha1_served = True
+
+        data['certs']['any_sha1_served'] = any_sha1_served
+
+        if data['certs'].get('constructed_issuer'):
+            data['certs']['any_sha1_constructed'] = target['certinfo']['has_sha1_in_certificate_chain']
 
     return data
 

--- a/scanners/sslyze.py
+++ b/scanners/sslyze.py
@@ -87,6 +87,7 @@ def scan(domain, options):
         return None
 
     yield [
+        scan_domain,
         data['protocols']['sslv2'], data['protocols']['sslv3'],
         data['protocols']['tlsv1.0'], data['protocols']['tlsv1.1'],
         data['protocols']['tlsv1.2'],
@@ -104,6 +105,7 @@ def scan(domain, options):
     ]
 
 headers = [
+    "Scanned Hostname",
     "SSLv2", "SSLv3", "TLSv1.0", "TLSv1.1", "TLSv1.2",
 
     "Any Forward Secrecy", "All Forward Secrecy",

--- a/scanners/sslyze.py
+++ b/scanners/sslyze.py
@@ -265,7 +265,7 @@ def parse_sslyze(raw_json):
         data['certs']['not_after'] = leaf.not_valid_after
 
         # Look at only served leaf and intermediate certificates
-        data['certs']['any_sha1'] = (not not target['certinfo']['has_sha1_in_certificate_chain'])
+        data['certs']['any_sha1'] = target['certinfo']['has_sha1_in_certificate_chain']
 
     return data
 

--- a/scanners/sslyze.py
+++ b/scanners/sslyze.py
@@ -2,8 +2,10 @@ import logging
 from scanners import utils
 import os
 
-from bs4 import BeautifulSoup
-import dateutil.parser
+import json
+import cryptography
+import cryptography.hazmat.backends.openssl
+import sslyze
 
 ###
 # == sslyze ==
@@ -12,15 +14,9 @@ import dateutil.parser
 #
 # If data exists for a domain from `pshtt`, will check results
 # and only process domains with valid HTTPS, or broken chains.
-#
-# Currently depends on pyenv to manage calling out to Python2 from Python3.
 ###
 
 command = os.environ.get("SSLYZE_PATH", "sslyze")
-
-# Kind of a hack for now, other methods of running sslyze with Python 2 welcome
-pyenv_version = os.environ.get("SSLYZE_PYENV", "2.7.11")
-
 
 def scan(domain, options):
     logging.debug("[%s][sslyze]" % domain)
@@ -37,41 +33,37 @@ def scan(domain, options):
     else:
         scan_domain = domain
 
-    # cache XML from sslyze
-    cache_xml = utils.cache_path(domain, "sslyze", ext="xml")
+    # cache JSON from sslyze
+    cache_json = utils.cache_path(domain, "sslyze")
     # because sslyze manages its own output (can't yet print to stdout),
     # we have to mkdir_p the path ourselves
-    utils.mkdir_p(os.path.dirname(cache_xml))
+    utils.mkdir_p(os.path.dirname(cache_json))
 
     force = options.get("force", False)
 
-    if (force is False) and (os.path.exists(cache_xml)):
+    if (force is False) and (os.path.exists(cache_json)):
         logging.debug("\tCached.")
-        xml = open(cache_xml).read()
+        raw_json = open(cache_json).read()
 
     else:
-        logging.debug("\t %s %s" % (command, scan_domain))
         # use scan_domain (possibly www-prefixed) to do actual scan
+        logging.debug("\t %s %s" % (command, scan_domain))
 
-        # Give the Python shell environment a pyenv environment.
-        pyenv_init = "eval \"$(pyenv init -)\" && pyenv shell %s" % pyenv_version
-        # Really un-ideal, but calling out to Python2 from Python 3 is a nightmare.
-        # I don't think this tool's threat model includes untrusted CSV, either.
-        raw = utils.unsafe_execute("%s && %s --regular --quiet %s --xml_out=%s" % (pyenv_init, command, scan_domain, cache_xml))
+        raw_response = utils.scan([command, "--regular", "--quiet", scan_domain, "--json_out=%s" % cache_json])
 
-        if raw is None:
-            # TODO: save standard invalid XML data...?
+        if raw_response is None:
+            # TODO: save standard invalid JSON data...?
             logging.warn("\tBad news scanning, sorry!")
             return None
 
-        xml = utils.scan(["cat", cache_xml])
-        if not xml:
-            logging.warn("\tBad news reading XML, sorry!")
+        raw_json = utils.scan(["cat", cache_json])
+        if not raw_json:
+            logging.warn("\tBad news reading JSON, sorry!")
             return None
 
-        utils.write(xml, cache_xml)
+        utils.write(raw_json, cache_json)
 
-    data = parse_sslyze(xml)
+    data = parse_sslyze(raw_json)
 
     if data is None:
         logging.warn("\tNo valid target for scanning, couldn't connect.")
@@ -88,12 +80,10 @@ def scan(domain, options):
         data['config'].get('weakest_dh'),
         data['config'].get('any_rc4'), data['config'].get('all_rc4'),
 
-        data['config'].get('ocsp_stapling'),
-
         data['certs'].get('key_type'), data['certs'].get('key_length'),
         data['certs'].get('leaf_signature'), data['certs'].get('any_sha1'),
         data['certs'].get('not_before'), data['certs'].get('not_after'),
-        data['certs'].get('served_issuer'),
+        data['certs'].get('served_issuer'), data['certs'].get('constructed_issuer'),
 
         data.get('errors')
     ]
@@ -105,38 +95,40 @@ headers = [
     "Weakest DH Group Size",
     "Any RC4", "All RC4",
 
-    "OCSP Stapling",
-
     "Key Type", "Key Length",
     "Signature Algorithm", "SHA-1 in Served Chain",
     "Not Before", "Not After",
-    "Highest Served Issuer",
+    "Highest Served Issuer", "Highest Constructed Issuer",
 
     "Errors"
 ]
 
-# Get the relevant fields out of sslyze's XML format. I couldn't find this documented
-# anywhere, so I'm just winging it by looking at example XML.
+# Get the relevant fields out of sslyze's JSON format.
+#
+# Certificate PEM data must be separately parsed using
+# the Python cryptography module.
+#
+# If we were using the sslyze Python API, this would be
+# done for us automatically, but serializing the results
+# to disk for caching would be prohibitively complex.
 
+def parse_sslyze(raw_json):
 
-def parse_sslyze(xml):
+    data = json.loads(raw_json)
 
-    doc = BeautifulSoup(xml, "xml")
-
-    # We'll just go after the first found valid target IP.
-    target = doc.select_one("target")
-
-    if target is None:
+    # 1. Isolate first successful scanned IP.
+    if len(data['accepted_targets']) == 0:
         return None
+    target = data['accepted_targets'][0]['commands_results']
 
     # Protocol version support.
     data = {
         'protocols': {
-            'sslv2': (target.find('sslv2')["isProtocolSupported"] == 'True'),
-            'sslv3': (target.find('sslv3')["isProtocolSupported"] == 'True'),
-            'tlsv1.0': (target.find('tlsv1')["isProtocolSupported"] == 'True'),
-            'tlsv1.1': (target.find('tlsv1_1')["isProtocolSupported"] == 'True'),
-            'tlsv1.2': (target.find('tlsv1_2')["isProtocolSupported"] == 'True')
+            'sslv2': (len(target['sslv2']["accepted_cipher_list"]) > 0),
+            'sslv3': (len(target['sslv3']["accepted_cipher_list"]) > 0),
+            'tlsv1.0': (len(target['tlsv1']["accepted_cipher_list"]) > 0),
+            'tlsv1.1': (len(target['tlsv1_1']["accepted_cipher_list"]) > 0),
+            'tlsv1.2': (len(target['tlsv1_2']["accepted_cipher_list"]) > 0)
         },
 
         'config': {},
@@ -146,12 +138,20 @@ def parse_sslyze(xml):
         'errors': None
     }
 
-    # Whether OCSP stapling is enabled.
-    ocsp = target.select_one('ocspStapling')
-    if ocsp:
-        data['config']['ocsp_stapling'] = (ocsp["isSupported"] == 'True')
+    # TODO: Whether OCSP stapling is enabled.
+    # Relevant fields: https://nabla-c0d3.github.io/sslyze/documentation/available-scan-commands.html#sslyze.plugins.certificate_info_plugin.CertificateInfoScanResult.ocsp_response
 
-    accepted_ciphers = target.select("acceptedCipherSuites cipherSuite")
+    # ocsp = target.select_one('ocspStapling')
+    # if ocsp:
+    #     data['config']['ocsp_stapling'] = (ocsp["isSupported"] == 'True')
+
+    accepted_ciphers = (
+        target['sslv2']["accepted_cipher_list"] +
+        target['sslv3']["accepted_cipher_list"] +
+        target['tlsv1']["accepted_cipher_list"] +
+        target['tlsv1_1']["accepted_cipher_list"] +
+        target['tlsv1_2']["accepted_cipher_list"]
+    )
 
     if len(accepted_ciphers) > 0:
         # Look at accepted cipher suites for RC4 or DHE.
@@ -162,7 +162,7 @@ def parse_sslyze(xml):
         all_rc4 = True
         all_dhe = True
         for cipher in accepted_ciphers:
-            name = cipher["name"]
+            name = cipher["openssl_name"]
             if "RC4" in name:
                 any_rc4 = True
             else:
@@ -180,11 +180,11 @@ def parse_sslyze(xml):
 
         # Find the weakest available DH group size, if any are available.
         weakest_dh = 1234567890  # nonsense maximum
-        groups = target.select("acceptedCipherSuites cipherSuite keyExchange[Type=DH]")
-        for group in groups:
-            size = int(group["GroupSize"])
-            if size < weakest_dh:
-                weakest_dh = size
+        for cipher in accepted_ciphers:
+            if cipher.get('dh_info', None) is not None:
+                size = int(cipher['dh_info']['GroupSize'])
+                if size < weakest_dh:
+                    weakest_dh = size
 
         if weakest_dh == 1234567890:
             weakest_dh = None
@@ -192,50 +192,74 @@ def parse_sslyze(xml):
         data['config']['weakest_dh'] = weakest_dh
 
     # If there was an exception parsing the certificate, catch it before fetching cert info.
-    if target.select_one("certinfo[exception]") is not None:
-        data['errors'] = target.select_one("certinfo[exception]")["exception"]
+    if False:
+        data['errors'] = "TODO"
 
     else:
 
-        # Find the issuer of the last served cert.
-        # This is an attempt at finding the CA name, but won't work if the served
-        # chain is incomplete. I'll take what I can get without doing path chasing.
-        chain = target.select_one("certificateChain")
+        # Served chain.
+        served_chain = target['certinfo']['certificate_chain']
 
-        if not chain:
-            chain = target.select_one("receivedCertificateChain")
+        # Constructed chain may not be there if it didn't validate.
+        constructed_chain = target['certinfo']['verified_certificate_chain']
 
-        certificates = chain.select("certificate")
-        issuer = certificates[-1].select_one("issuer commonName")
-        if not issuer:
-            issuer = certificates[-1].select_one("issuer organizationalUnitName")
+        highest_served = parse_cert(served_chain[-1])
+        issuer = cert_issuer_name(highest_served)
 
-        if issuer and issuer.text:
-            data['certs']['served_issuer'] = issuer.text
+        if issuer:
+            data['certs']['served_issuer'] = issuer
         else:
             data['certs']['served_issuer'] = "(None found)"
 
-        leaf = chain.select_one("certificate[position=leaf]")
+        if (constructed_chain and (len(constructed_chain) > 0)):
+            highest_constructed = parse_cert(constructed_chain[-1])
+            issuer = cert_issuer_name(highest_constructed)
+            if issuer:
+                data['certs']['constructed_issuer'] = issuer
+            else:
+                data['certs']['constructed_issuer'] = "(None constructed)"
 
-        # Key algorithm and length for leaf certificate only.
-        data['certs']['key_type'] = leaf.select_one("subjectPublicKeyInfo publicKeyAlgorithm").text
-        data['certs']['key_length'] = int(leaf.select_one("subjectPublicKeyInfo publicKeySize").text)
+        leaf = parse_cert(served_chain[0])
+        leaf_key = leaf.public_key()
+
+        data['certs']['key_length'] = leaf_key.key_size
+
+        if leaf_key.__class__ == cryptography.hazmat.backends.openssl.rsa._RSAPublicKey:
+            leaf_key_type = "RSA"
+        elif leaf_key.__class__ == cryptography.hazmat.backends.openssl.dsa._DSAPublicKey:
+            leaf_key_type = "DSA"
+        elif leaf_key.__class__ == cryptography.hazmat.backends.openssl.ec._EllipticCurvePublicKey:
+            leaf_key_type = "ECDSA"
+        else:
+            leaf_key_type == str(leaf_key.__class__)
+
+        data['certs']['key_type'] = leaf_key_type
 
         # Signature of the leaf certificate only.
-        data['certs']['leaf_signature'] = leaf.select_one("signatureAlgorithm").text
+        data['certs']['leaf_signature'] = leaf.signature_hash_algorithm.name
 
         # Beginning and expiration dates of the leaf certificate
-        before_date = leaf.select_one("validity notBefore").text
-        after_date = leaf.select_one("validity notAfter").text
-        data['certs']['not_before'] = dateutil.parser.parse(before_date)
-        data['certs']['not_after'] = dateutil.parser.parse(after_date)
+        data['certs']['not_before'] = leaf.not_valid_before
+        data['certs']['not_after'] = leaf.not_valid_after
 
         # Look at only served leaf and intermediate certificates
-        signatures = target.select("certificateChain certificate[position=leaf],certificate[position=intermediate] signatureAlgorithm")
-        any_sha1 = False
-        for signature in signatures:
-            if "sha1With" in signature.text:
-                any_sha1 = True
-        data['certs']['any_sha1'] = any_sha1
+        data['certs']['any_sha1'] = target['certinfo']['has_sha1_in_certificate_chain']
 
     return data
+
+# Given the cert sub-obj from the sslyze JSON, use
+# the cryptography module to parse its PEM contents.
+def parse_cert(cert):
+    backend = cryptography.hazmat.backends.openssl.backend
+    pem_bytes = cert['as_pem'].encode('utf-8')
+    return cryptography.x509.load_pem_x509_certificate(pem_bytes, backend)
+
+# Given a parsed cert from the cryptography module,
+# get the issuer name as best as possible
+def cert_issuer_name(parsed):
+    attrs = parsed.issuer.get_attributes_for_oid(cryptography.x509.oid.NameOID.COMMON_NAME)
+    if len(attrs) == 0:
+        attrs = parsed.issuer.get_attributes_for_oid(cryptography.x509.oid.NameOID.ORGANIZATIONAL_UNIT_NAME)
+    if len(attrs) == 0:
+        return None
+    return attrs[0].value

--- a/scanners/sslyze.py
+++ b/scanners/sslyze.py
@@ -263,7 +263,7 @@ def parse_sslyze(raw_json):
         data['certs']['not_after'] = leaf.not_valid_after
 
         # Look at only served leaf and intermediate certificates
-        data['certs']['any_sha1'] = target['certinfo']['has_sha1_in_certificate_chain']
+        data['certs']['any_sha1'] = (not not target['certinfo']['has_sha1_in_certificate_chain'])
 
     return data
 

--- a/scanners/utils.py
+++ b/scanners/utils.py
@@ -219,6 +219,9 @@ def domain_doesnt_support_https(domain):
     if not inspection:
         return False
 
+    if (inspection.__class__ is dict) and inspection.get('invalid'):
+        return False
+
     # TODO: kill this
     inspection = inspection[0]
 
@@ -242,6 +245,9 @@ def domain_uses_www(domain):
     inspection = data_for(domain, "pshtt")
     if not inspection:
         return False
+    if (inspection.__class__ is dict) and inspection.get('invalid'):
+        return False
+
     # TODO: kill this
     inspection = inspection[0]
 


### PR DESCRIPTION
This updates to sslyze 1.X, which has a new stable Python API, **works in Python 3**, and a revamped approach to certificate parsing.

Unfortunately, I'm not easily able to take full advantage of the Python API while retaining the ability to cache all fetched network data to disk to replay scans, because the Python API doesn't have an easy way to serialize (to JSON or XML) the full results of the scan from within that interface. 

So, I continue to shell out to calling `sslyze`, but this is improved in two ways:

* It drops the use of pyenv, since we're now not depending on Python 2.x. So this also now uses the `utils.scan()` command instead of `utils.unsafe_execute()`.
* It uses JSON as a serialization format instead of XML, from sslyze's `--json_out` flag.

sslyze now doesn't parse certificate info for you in the JSON or XML output, instead asking relying parties to parse the x.509 certificates themselves. So, this makes use of the `cryptography` module to parse PEMs directly.

Some other notes:

* I dropped the OCSP stapling field, since it's harder to get and not as important.
* I added a `Highest Constructed Issuer` field, since sslyze now gives you the full constructed chain -- **if** it was able to verify the chain to one of its included trust stores.
* There's more I could do with time -- the data is richer and better than ever before. This is mostly just trying to be a drop-in replacement for now.