### PR TITLE
Gathering from multiple sources at once

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,10 +144,27 @@ Usage:
 ./gather [source] [options]
 ```
 
-Where source is one of:
+Or gather hostnames from multiple sources separated by commas:
 
-* `censys` - Walks the [Censys.io API](https://censys.io/api), which has hostnames gathered from observed certificates. Censys provides certificates observed from a nightly zmap scan of the IPv4 space, as well as certificates published to public Certificate Transparency logs.
-* `url` - Given a path to a CSV, reads it and applies deduping and filtering logic. Its only option is `--url`, which can be a URL (starts with `http:` or `https:`) or a local path.
+```bash
+./gather [source1,source2,...,sourceN] [options]
+```
+
+Right now there's one specific source (Censys.io), and then a general way of sourcing URLs or files by whatever name is convenient.
+
+**Censys.io** - The `censys` gatherer uses the [Censys.io API](https://censys.io/api), which has hostnames gathered from observed certificates. Censys provides certificates observed from a nightly zmap scan of the IPv4 space, as well as certificates published to public Certificate Transparency logs. Use `--export` to use the Censys.io Export API, which is faster and more complete but requires researcher credentials.
+
+**Remote or local CSV** - Given a URL or local path to a CSV, downloads and/or reads it. Its only option is `--url`, which can be a URL (starts with `http:` or `https:`) or a local path.
+
+Hostnames found from multiple sources are deduped, and filtered by suffix or base domain according to the options given.
+
+The resulting `gathered.csv` will have the following columns:
+
+* the hostname
+* the hostname's base domain
+* one column for each checked source, with a value of True/False based on the hostname's presence in each source
+
+See [specific usage examples](#gathering-usage-examples) below.
 
 General options:
 
@@ -181,6 +198,26 @@ Find `.gov` certificates in the first 2 pages of Censys API results, waiting 5 s
 
 ```bash
 ./gather censys --suffix=.gov --start=1 --end=2 --delay=5
+```
+
+### Gathering Usage Examples
+
+To gather .gov hostnames from Censys.io's Export API:
+
+```bash
+./gather censys --suffix=.gov --export --debug
+```
+
+To gather .gov hostnames from a hosted CSV, such as one from the [Digital Analytics Program](https://analytics.usa.gov):
+
+```bash
+./gather dap --suffix=.gov --dap=https://analytics.usa.gov/data/live/sites-extended.csv
+```
+
+Or to gather federal-only .gov hostnames from Censys.io's Export API, a remote CSV, and a local CSV:
+
+```bash
+./gather censys,dap,private --suffix=.gov --dap=https://analytics.usa.gov/data/live/sites-extended.csv --private=/path/to/private-research.csv --parents=https://raw.githubusercontent.com/GSA/data/gh-pages/dotgov-domains/current-federal.csv --export
 ```
 
 ### a11y setup

--- a/README.md
+++ b/README.md
@@ -152,9 +152,9 @@ Or gather hostnames from multiple sources separated by commas:
 
 Right now there's one specific source (Censys.io), and then a general way of sourcing URLs or files by whatever name is convenient.
 
-**Censys.io** - The `censys` gatherer uses the [Censys.io API](https://censys.io/api), which has hostnames gathered from observed certificates. Censys provides certificates observed from a nightly zmap scan of the IPv4 space, as well as certificates published to public Certificate Transparency logs. Use `--export` to use the Censys.io Export API, which is faster and more complete but requires researcher credentials.
+**Censys.io** - The `censys` gatherer uses the [Censys.io API](https://censys.io/api), which has hostnames gathered from observed certificates. Censys provides certificates observed from a nightly zmap scan of the IPv4 space, as well as certificates published to public Certificate Transparency logs. Use `--export` to use the [Censys.io Export API](https://censys.io/api/v1/docs/export), which is faster and more complete but requires researcher credentials.
 
-**Remote or local CSV** - Given a URL or local path to a CSV, downloads and/or reads it. Its only option is `--url`, which can be a URL (starts with `http:` or `https:`) or a local path.
+**Remote or local CSV** - By using any other name besides `censys`, this will define a gatherer based on an HTTP/HTTPS URL or local path to a CSV. Its only option is a flag named after itself. For example, using a gatherer name of `dap` will mean that domain-scan expects `--dap` to point to the URL or local file.
 
 Hostnames found from multiple sources are deduped, and filtered by suffix or base domain according to the options given.
 
@@ -202,7 +202,7 @@ Find `.gov` certificates in the first 2 pages of Censys API results, waiting 5 s
 
 ### Gathering Usage Examples
 
-To gather .gov hostnames from Censys.io's Export API:
+To gather .gov hostnames from [Censys.io's Export API](https://censys.io/api/v1/docs/export):
 
 ```bash
 ./gather censys --suffix=.gov --export --debug
@@ -214,7 +214,7 @@ To gather .gov hostnames from a hosted CSV, such as one from the [Digital Analyt
 ./gather dap --suffix=.gov --dap=https://analytics.usa.gov/data/live/sites-extended.csv
 ```
 
-Or to gather federal-only .gov hostnames from Censys.io's Export API, a remote CSV, and a local CSV:
+Or to gather federal-only .gov hostnames from [Censys.io's Export API](https://censys.io/api/v1/docs/export), a remote CSV, and a local CSV:
 
 ```bash
 ./gather censys,dap,private --suffix=.gov --dap=https://analytics.usa.gov/data/live/sites-extended.csv --private=/path/to/private-research.csv --parents=https://raw.githubusercontent.com/GSA/data/gh-pages/dotgov-domains/current-federal.csv --export

--- a/gather
+++ b/gather
@@ -53,16 +53,24 @@ def run(options=None):
     hostnames_cache = {}
 
     for source in sources:
+        extra = {}
 
         try:
             gatherer = importlib.import_module("gatherers.%s" % source)
         except ImportError:
-            exc_type, exc_value, exc_traceback = sys.exc_info()
-            logging.error("[%s] Gatherer not found, or had an error during loading.\n\tERROR: %s\n\t%s" % (source, exc_type, exc_value))
-            exit(1)
+            # If it's not a registered module, allow it to be "hot registered"
+            # as long as the user gave us a flag with that name that can be
+            # used as the --url option to the URL module.
+            if options.get(source):
+                gatherer = importlib.import_module("gatherers.url")
+                extra['name'] = source
+            else:
+                exc_type, exc_value, exc_traceback = sys.exc_info()
+                logging.error("[%s] Gatherer not found, or had an error during loading.\n\tERROR: %s\n\t%s" % (source, exc_type, exc_value))
+                exit(1)
 
         # Iterate over each hostname.
-        for domain in gatherer.gather(suffix, options):
+        for domain in gatherer.gather(suffix, options, extra):
 
             # Always apply the suffix to returned names.
             if not suffix_pattern.search(domain):
@@ -106,6 +114,7 @@ def run(options=None):
     hostnames.sort()
 
     for hostname in hostnames:
+        base = utils.base_domain_for(hostname)
         row = [hostname, base]
         for source in sources:
             row += [source in hostnames_cache[hostname]]

--- a/gather
+++ b/gather
@@ -48,11 +48,6 @@ def run(options=None):
     else:
         filename = sources[0] # backwards compatibility, mostly
 
-    gathered_filename = "%s/%s.csv" % (utils.results_dir(), filename)
-    gathered_file = open(gathered_filename, 'w', newline='')
-    gathered_writer = csv.writer(gathered_file)
-    gathered_writer.writerow(["Domain", "Base Domain", "Source"])
-
     # De-duping hostnames. This will cause the system to hold all
     # hostnames in memory at once, but oh well.
     hostnames_cache = {}
@@ -68,6 +63,7 @@ def run(options=None):
 
         # Iterate over each hostname.
         for domain in gatherer.gather(suffix, options):
+
             # Always apply the suffix to returned names.
             if not suffix_pattern.search(domain):
                 continue
@@ -86,11 +82,34 @@ def run(options=None):
 
             # Use hostname cache to de-dupe, if seen before.
             if domain not in hostnames_cache:
+                hostnames_cache[domain] = [source]
+            elif source not in hostnames_cache[domain]:
+                hostnames_cache[domain] += [source]
 
-                # Finally, write out the hostname, and cache it.
-                gathered_writer.writerow([domain, base, source])
-                hostnames_cache[domain] = None
+    # Now that we've gone through all sources and logged when each
+    # domain appears in each one, go through cache and write
+    # all of them to disk.
 
+    # Assemble headers.
+    headers = ["Domain", "Base Domain"]
+    # Add headers dynamically for each source.
+    headers += sources
+
+    # Open CSV file.
+    gathered_filename = "%s/%s.csv" % (utils.results_dir(), filename)
+    gathered_file = open(gathered_filename, 'w', newline='')
+    gathered_writer = csv.writer(gathered_file)
+    gathered_writer.writerow(headers)
+
+    # Write each hostname to disk, with all discovered sources.
+    hostnames = list(hostnames_cache.keys())
+    hostnames.sort()
+
+    for hostname in hostnames:
+        row = [hostname, base]
+        for source in sources:
+            row += [source in hostnames_cache[hostname]]
+        gathered_writer.writerow(row)
 
     # Close CSV file.
     gathered_file.close()

--- a/gather
+++ b/gather
@@ -24,16 +24,6 @@ def run(options=None):
         logging.error("Specify a gatherer.")
         exit(1)
 
-    # Import the gatherer.
-    source = options["_"][0]
-    try:
-        gatherer = importlib.import_module("gatherers.%s" % source)
-    except ImportError:
-        exc_type, exc_value, exc_traceback = sys.exc_info()
-        logging.error("[%s] Gatherer not found, or had an error during loading.\n\tERROR: %s\n\t%s" % (source, exc_type, exc_value))
-        exit(1)
-
-
     # For now, require a --suffix.
     suffix = utils.normalize_suffix(options.get("suffix"))
     if suffix is None:
@@ -49,40 +39,57 @@ def run(options=None):
     parents = get_parent_domains(options)
 
 
+    # Import the gatherer(s).
+    sources = options["_"][0].split(",")
+
     # Open CSV writer.
-    gathered_filename = "%s/%s.csv" % (utils.results_dir(), source)
+    if len(sources) > 1:
+        filename = "gathered"
+    else:
+        filename = sources[0] # backwards compatibility, mostly
+
+    gathered_filename = "%s/%s.csv" % (utils.results_dir(), filename)
     gathered_file = open(gathered_filename, 'w', newline='')
     gathered_writer = csv.writer(gathered_file)
-    gathered_writer.writerow(["Domain", "Base Domain"])
+    gathered_writer.writerow(["Domain", "Base Domain", "Source"])
 
     # De-duping hostnames. This will cause the system to hold all
     # hostnames in memory at once, but oh well.
     hostnames_cache = {}
 
-    # Iterate over each hostname.
-    for domain in gatherer.gather(suffix, options):
-        # Always apply the suffix to returned names.
-        if not suffix_pattern.search(domain):
-            continue
+    for source in sources:
 
-        base = utils.base_domain_for(domain)
+        try:
+            gatherer = importlib.import_module("gatherers.%s" % source)
+        except ImportError:
+            exc_type, exc_value, exc_traceback = sys.exc_info()
+            logging.error("[%s] Gatherer not found, or had an error during loading.\n\tERROR: %s\n\t%s" % (source, exc_type, exc_value))
+            exit(1)
 
-        # Unless --include-parents is specified, exclude them.
-        if not include_parents:
-            if (domain == base) or (domain == "www.%s" % base):
+        # Iterate over each hostname.
+        for domain in gatherer.gather(suffix, options):
+            # Always apply the suffix to returned names.
+            if not suffix_pattern.search(domain):
                 continue
 
-        # Apply --parent domain whitelist, if present.
-        if parents:
-            if base not in parents:
-                continue
+            base = utils.base_domain_for(domain)
 
-        # Use hostname cache to de-dupe, if seen before.
-        if domain not in hostnames_cache:
+            # Unless --include-parents is specified, exclude them.
+            if not include_parents:
+                if (domain == base) or (domain == "www.%s" % base):
+                    continue
 
-            # Finally, write out the hostname, and cache it.
-            gathered_writer.writerow([domain, base])
-            hostnames_cache[domain] = None
+            # Apply --parent domain whitelist, if present.
+            if parents:
+                if base not in parents:
+                    continue
+
+            # Use hostname cache to de-dupe, if seen before.
+            if domain not in hostnames_cache:
+
+                # Finally, write out the hostname, and cache it.
+                gathered_writer.writerow([domain, base, source])
+                hostnames_cache[domain] = None
 
 
     # Close CSV file.

--- a/gatherers/censys.py
+++ b/gatherers/censys.py
@@ -49,7 +49,7 @@ import censys
 wildcard_pattern = re.compile("^\*\.")
 redacted_pattern = re.compile("^(\?\.)+")
 
-def gather(suffix, options):
+def gather(suffix, options, extra={}):
     # Register a (free) Censys.io account to get a UID and API key.
     uid = options.get("censys_id", None)
     api_key = options.get("censys_key", None)

--- a/gatherers/url.py
+++ b/gatherers/url.py
@@ -12,8 +12,11 @@ import logging
 #
 
 
-def gather(suffix, options):
-    url = options.get("url")
+def gather(suffix, options, extra={}):
+    # Defaults to --url, but can be overridden.
+    name = extra.get("name", "url")
+    url = options.get(name)
+
     if url is None:
         logging.warn("A --url is required. (Can be a local path.)")
         exit(1)

--- a/scanners/sslyze.py
+++ b/scanners/sslyze.py
@@ -5,6 +5,7 @@ import os
 import json
 import cryptography
 import cryptography.hazmat.backends.openssl
+from cryptography.hazmat.primitives.asymmetric import ec, dsa, rsa
 import sslyze
 
 ###
@@ -250,11 +251,11 @@ def parse_sslyze(raw_json):
         else:
             data['certs']['key_length'] = None
 
-        if leaf_key.__class__ == cryptography.hazmat.backends.openssl.rsa._RSAPublicKey:
+        if isinstance(leaf_key, rsa.RSAPublicKey):
             leaf_key_type = "RSA"
-        elif leaf_key.__class__ == cryptography.hazmat.backends.openssl.dsa._DSAPublicKey:
+        elif isinstance(leaf_key, dsa.DSAPublicKey):
             leaf_key_type = "DSA"
-        elif leaf_key.__class__ == cryptography.hazmat.backends.openssl.ec._EllipticCurvePublicKey:
+        elif isinstance(leaf_key, ec.EllipticCurvePublicKey):
             leaf_key_type = "ECDSA"
         else:
             leaf_key_type == str(leaf_key.__class__)


### PR DESCRIPTION
This pull request adds a new way of gathering hostnames from multiple sources at once. Results are collectively deduped, and the resulting CSV will show whether each hostname was found in each checked source.

An example (real-world) use of this facility, to gather publicly discoverable federal .gov hostnames from Censys.io, the Digital Analytics Program, the 2016 End of Term Archive, and the official .gov domain list:

```bash
./gather censys,dap,eot2016,parents --eot2016=https://github.com/GSA/data/raw/gh-pages/end-of-term-archive-csv/eot-2016-seeds.csv --dap=https://analytics.usa.gov/data/live/sites-extended.csv --suffix=.gov --parents=https://raw.githubusercontent.com/GSA/data/gh-pages/dotgov-domains/current-federal.csv --include-parents --debug --export
```
As shown in this example, simple URL/file-based gatherers are dynamically created by giving them a name that isn't already defined as a gatherer (right now, anything other than `censys`), and then specified by using a command line flag with the same name. This dynamic approach is used to keep syntax simple and avoid having to use more complicated syntax (such as numerically sequenced names), while allowing multiple URL/file-based gatherers to run separately without their namespaces colliding.