### PR TITLE
Gracefully handle unauthorized Censys.io Export API credentials

### DIFF
--- a/gatherers/censys.py
+++ b/gatherers/censys.py
@@ -176,7 +176,7 @@ def export_mode(suffix, options, uid, api_key):
     try:
         export_api = export.CensysExport(uid, api_key)
     except censys.base.CensysUnauthorizedException:
-        logging.warn("Censys.io rejected the provided Censys credentials, they are not authorized to use the Export API.")
+        logging.warn("The Censys.io Export API rejected the provided Censys credentials. The credentials may be inaccurate, or you may need to request access from the Censys.io team.")
         exit(1)
 
     # Uses a FLATTEN command in order to work around a BigQuery

--- a/gatherers/censys.py
+++ b/gatherers/censys.py
@@ -173,7 +173,11 @@ def export_mode(suffix, options, uid, api_key):
     # Wait 5 seconds between checking on the job.
     between_jobs = 5
 
-    export_api = export.CensysExport(uid, api_key)
+    try:
+        export_api = export.CensysExport(uid, api_key)
+    except censys.base.CensysUnauthorizedException:
+        logging.warn("Censys.io rejected the provided Censys credentials, they are not authorized to use the Export API.")
+        exit(1)
 
     # Uses a FLATTEN command in order to work around a BigQuery
     # error around multiple "repeated" fields. *shrug*


### PR DESCRIPTION
We already gracefully handle missing Censys.io API credentials. This PR handles the case where we have been given Censys.io API credentials that are either invalid, or otherwise not authorized to use the Censys.io Export API.

Fixes #128.