### PR TITLE
Cache preload list across individual runs of pshtt, not domain-scan

### DIFF
--- a/scanners/pshtt.py
+++ b/scanners/pshtt.py
@@ -27,6 +27,16 @@ user_agent = os.environ.get("PSHTT_USER_AGENT", "github.com/18f/domain-scan, psh
 preload_cache = utils.cache_single("preload-list.json")
 
 
+# The preload list cache is only important across individual
+# executions of pshtt. Not intended to be cached across
+# individual executions of domain-scan itself.
+def init(options):
+    if os.path.exists(preload_cache):
+        logging.warn("Clearing cached preload-list.json file before scanning.")
+        os.remove(preload_cache)
+    return True
+
+
 def scan(domain, options):
     logging.debug("[%s][pshtt]" % domain)
 
@@ -45,12 +55,6 @@ def scan(domain, options):
 
     else:
         logging.debug("\t %s %s" % (command, domain))
-
-        # The preload list cache is only important across individual
-        # executions of pshtt. Not intended to be cached across
-        # individual executions of domain-scan itself.
-        if os.path.exists(preload_cache):
-            os.remove(preload_cache)
 
         flags = "--json --user-agent \"%s\" --timeout %i --preload-cache %s" % (user_agent, timeout, preload_cache)
 

--- a/scanners/pshtt.py
+++ b/scanners/pshtt.py
@@ -46,6 +46,12 @@ def scan(domain, options):
     else:
         logging.debug("\t %s %s" % (command, domain))
 
+        # The preload list cache is only important across individual
+        # executions of pshtt. Not intended to be cached across
+        # individual executions of domain-scan itself.
+        if os.path.exists(preload_cache):
+            os.remove(preload_cache)
+
         flags = "--json --user-agent \"%s\" --timeout %i --preload-cache %s" % (user_agent, timeout, preload_cache)
 
         # Only useful when debugging interaction between projects.


### PR DESCRIPTION
`domain-scan` sets the `--preload-cache` option for `pshtt` only to keep the preload list JSON cached across each individual run of `pshtt`, to avoid constantly re-downloading it.

However, we weren't flushing this cache in any way between runs of `domain-scan`, so any repeated runs of `domain-scan` in the same directory were reusing the same `preload-list.json` file ad infinitum.

This PR automatically deletes any cached `preload-list.json` file before the `pshtt` scanner is initialized, which ensures that a fresh one will be used for any batch of `pshtt` calls.

Fixes #707.