### PR TITLE
Drops awkward pyenv shell-out for the pshtt scanner

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,30 +5,29 @@
 
 Scans domains for data on their HTTPS configuration and assorted other things.
 
-**Most of the work is farmed out to other command line tools.** The point of this project is to **coordinate** those tools and produce **consistent data output**.
+**Much of this work is farmed out to other command line tools.**
 
-Can be used with any domain, or CSV where domains are the first column, such as the [official .gov domain list](https://catalog.data.gov/dataset/gov-domains-api-c9856).
+The point of this project is to **coordinate** and **parallelize** those tools and produce **consistent data output**.
+
+Can be used with any domain, or any CSV where domains are the first column, such as the [official .gov domain list](https://github.com/GSA/data/raw/gh-pages/dotgov-domains/current-full.csv).
 
 ### Requirements
 
-The requirements here can be quite diverse, because this tool is just a coordinator for other tools. Communication between tools is handled via CLI and STDOUT.
-
-The overall tool requires **Python 3**. To install dependencies:
+`domain-scan` requires **Python 3**. To install dependencies:
 
 ```bash
 pip install -r requirements.txt
 ```
 
-The individual scanners each require their own dependencies. You only need to have the dependencies installed for the scanners you plan to use.
+Some individual scanners require externally installed dependencies:
 
-* `pshtt` scanner: **Python 2** and **[pshtt](https://github.com/dhs-ncats/pshtt)**, ideally installed with `pyenv` via `pip install pshtt`.
-* `tls` scanner: **Go** and **[ssllabs-scan](https://github.com/ssllabs/ssllabs-scan)**, stable branch.
-* `sslyze` scanner: **[sslyze](https://github.com/nabla-c0d3/sslyze)** 1.0 or greater (installed automatically via `requirements.txt`).
-* `pageload` scanner: **Node** and **[phantomas](https://www.npmjs.com/package/phantomas)**, installed through npm.
+* `pshtt` scanner: The `pshtt` command, available from the [`pshtt`](https://github.com/dhs-ncats/pshtt) Python package.
+* `tls` scanner: The `ssllabs-scan` command, available by compiling and installing from the Go-based [ssllabs-scan](https://github.com/ssllabs/ssllabs-scan) repo (stable branch).
+* `pageload` scanner: The `phantomas` command, available from the [`phantomas`](https://www.npmjs.com/package/phantomas) Node package.
 
 ##### Setting tool paths
 
-By default, domain-scan will expect the paths to any executables to be on the system PATH.
+By default, `domain-scan` will expect the paths to any executables to be on the system PATH.
 
 If you need to point it to a local directory instead, you'll need to set environment variables to override this.
 
@@ -79,7 +78,7 @@ Parallelization will also cause the resulting domains to be written in an unpred
 * `pshtt` - HTTP/HTTPS/HSTS configuration with the python-only [`pshtt`](https://github.com/dhs-ncats/pshtt) tool.
 * `tls` - TLS configuration, using the [SSL Labs API](https://github.com/ssllabs/ssllabs-scan/blob/stable/ssllabs-api-docs.md).
 * `sslyze` - TLS configuration, using [`sslyze`](https://github.com/nabla-c0d3/sslyze).
-* `analytics` - Participation in an analytics program.
+* `analytics` - Participation in an analytics program. (Optimized for USG.)
 * `pageload` - Page load and rendering metrics.
 * `a11y` - Accessibility data with the [`pa11y` CLI tool](https://github.com/pa11y/pa11y)
 

--- a/scanners/pshtt.py
+++ b/scanners/pshtt.py
@@ -67,12 +67,14 @@ def scan(domain, options):
         # I don't think this tool's threat model includes untrusted CSV, either.
         # raw = utils.unsafe_execute("%s && %s %s %s" % (pyenv_init, command, domain, flags))
 
-        raw = utils.scan([command,
-                         '--json',
-                         '--user-agent', '\"%s\"' % user_agent,
-                         '--timeout', '%i' % timeout,
-                         '--preload-cache', '%s' % preload_cache,
-                         '%s' % domain])
+        raw = utils.scan([
+            command,
+            '--json',
+            '--user-agent', '\"%s\"' % user_agent,
+            '--timeout', '%i' % timeout,
+            '--preload-cache', '%s' % preload_cache,
+            '%s' % domain
+        ])
 
         if not raw:
             utils.write(utils.invalid({}), cache_pshtt)

--- a/scanners/pshtt.py
+++ b/scanners/pshtt.py
@@ -8,13 +8,9 @@ import json
 #
 # Inspect a site's TLS configuration using DHS NCATS' pshtt tool.
 #
-# Currently depends on pyenv to manage calling out to Python2 from Python3.
 ###
 
 command = os.environ.get("PSHTT_PATH", "pshtt")
-
-# Kind of a hack for now, other methods of running pshtt with Python 2 welcome
-pyenv_version = os.environ.get("PSHTT_PYENV", "2.7.11")
 
 # default to a long timeout
 timeout = 30
@@ -56,24 +52,13 @@ def scan(domain, options):
     else:
         logging.debug("\t %s %s" % (command, domain))
 
-        # flags = "--json --user-agent \"%s\" --timeout %i --preload-cache %s" % (user_agent, timeout, preload_cache)
-
-        # Only useful when debugging interaction between projects.
-        # flags = "%s --debug" % flags
-
-        # Give the Python shell environment a pyenv environment.
-        # pyenv_init = "eval \"$(pyenv init -)\" && pyenv shell %s" % pyenv_version
-        # Really un-ideal, but calling out to Python2 from Python 3 is a nightmare.
-        # I don't think this tool's threat model includes untrusted CSV, either.
-        # raw = utils.unsafe_execute("%s && %s %s %s" % (pyenv_init, command, domain, flags))
-
         raw = utils.scan([
             command,
+            domain,
             '--json',
             '--user-agent', '\"%s\"' % user_agent,
-            '--timeout', '%i' % timeout,
-            '--preload-cache', '%s' % preload_cache,
-            '%s' % domain
+            '--timeout', str(timeout),
+            '--preload-cache', preload_cache
         ])
 
         if not raw:


### PR DESCRIPTION
This updates the `pshtt` scanner to drop the use of `pyenv` to call out to `pshtt`, since `pshtt` now supports Python 3 (since `sslyze` now supports Python 3).

Builds on #134 (and incorporates @ultiferrago's commits and should cause #134 to be merged), while more fully removing the comments and code associated with the use of pyenv, as well as updating the README.