### PR TITLE
Add new fields from pshtt

### DIFF
--- a/scanners/pshtt.py
+++ b/scanners/pshtt.py
@@ -88,10 +88,11 @@ def scan(domain, options):
 
 headers = [
     "Canonical URL", "Live", "Redirect", "Redirect To",
-    "Valid HTTPS", "Defaults to HTTPS", "Downgrades HTTPS", "Strictly Forces HTTPS",
-    "HTTPS Bad Chain", "HTTPS Bad Hostname", "HTTPS Expired Cert",
+    "Valid HTTPS", "Defaults to HTTPS", "Downgrades HTTPS",
+    "Strictly Forces HTTPS", "HTTPS Bad Chain", "HTTPS Bad Hostname",
+    "HTTPS Expired Cert", "HTTPS Self Signed Cert",
     "HSTS", "HSTS Header", "HSTS Max Age", "HSTS Entire Domain",
     "HSTS Preload Ready", "HSTS Preload Pending", "HSTS Preloaded",
     "Base Domain HSTS Preloaded", "Domain Supports HTTPS",
-    "Domain Enforces HTTPS", "Domain Uses Strong HSTS"
+    "Domain Enforces HTTPS", "Domain Uses Strong HSTS", "Unknown Error"
 ]

--- a/scanners/pshtt.py
+++ b/scanners/pshtt.py
@@ -94,5 +94,5 @@ headers = [
     "HSTS", "HSTS Header", "HSTS Max Age", "HSTS Entire Domain",
     "HSTS Preload Ready", "HSTS Preload Pending", "HSTS Preloaded",
     "Base Domain HSTS Preloaded", "Domain Supports HTTPS",
-    "Domain Enforces HTTPS", "Domain Uses Strong HSTS", "Unknown Error"
+    "Domain Enforces HTTPS", "Domain Uses Strong HSTS", "Unknown Error",
 ]


### PR DESCRIPTION
"HTTPS Self Signed Cert”, and “Unknown Error” were added to pshtt in the last few months ([here](https://github.com/dhs-ncats/pshtt/commit/2c33255f856b64fc4cc367c82b809ef0befc5a52) and [here](https://github.com/dhs-ncats/pshtt/commit/129f112ec3390da17ed61fd1d05477897708572c), respectively). This change allows these fields to be represented in domain-scan scans.