### PR TITLE
Added caching for public suffix list for pshtt

### DIFF
--- a/scanners/pshtt.py
+++ b/scanners/pshtt.py
@@ -22,14 +22,20 @@ user_agent = os.environ.get("PSHTT_USER_AGENT", "github.com/18f/domain-scan, psh
 # same format as inspect.py uses
 preload_cache = utils.cache_single("preload-list.json")
 
+# save (and look for) preload file in cache/public-suffix-list.json
+public_suffix_cache = utils.cache_single("public-suffix-list.json")
 
-# The preload list cache is only important across individual
-# executions of pshtt. Not intended to be cached across
+
+# The preload and public suffix list caches are only important across
+# individual executions of pshtt. They are not intended to be cached across
 # individual executions of domain-scan itself.
 def init(options):
     if os.path.exists(preload_cache):
         logging.warn("Clearing cached preload-list.json file before scanning.")
         os.remove(preload_cache)
+    if os.path.exists(public_suffix_cache):
+        logging.warn("Clearing cached public-suffix-list.json file before scanning.")
+        os.remove(public_suffix_cache)
     return True
 
 
@@ -58,7 +64,8 @@ def scan(domain, options):
             '--json',
             '--user-agent', '\"%s\"' % user_agent,
             '--timeout', str(timeout),
-            '--preload-cache', preload_cache
+            '--preload-cache', preload_cache,
+            '--suffix-cache', public_suffix_cache
         ])
 
         if not raw:


### PR DESCRIPTION
The [public suffix list](https://publicsuffix.org/), which is only updated weekly, was being downloaded for each instance of `pshtt` that `domain-scan` was kicking off.  This change caches the public suffix list data, very similarly to the way the preload data is cached.