### PR TITLE
Correct load_domains behavior for skipping rows

### DIFF
--- a/scanners/utils.py
+++ b/scanners/utils.py
@@ -315,10 +315,15 @@ def load_domains(domain_csv, whole_rows=False):
     domains = []
     with open(domain_csv, newline='') as csvfile:
         for row in csv.reader(csvfile):
-            if (not row[0]) or (row[0].lower().startswith("domain")):
+            # Skip empty rows.
+            if (not row) or (not row[0].strip()):
                 continue
 
             row[0] = row[0].lower()
+            
+            # Skip any header row.
+            if (not domains) and (row[0].startswith("domain")):
+                continue
 
             if whole_rows:
                 domains.append(row)

--- a/scanners/utils.py
+++ b/scanners/utils.py
@@ -320,7 +320,7 @@ def load_domains(domain_csv, whole_rows=False):
                 continue
 
             row[0] = row[0].lower()
-            
+
             # Skip any header row.
             if (not domains) and (row[0].startswith("domain")):
                 continue


### PR DESCRIPTION
Ignore empty lines and only ignore a "header" if it's the first entry in the file.