### PR TITLE
Using SSLyze as a Python library instead of shelling out

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -153,8 +153,6 @@ RUN pip3 install pshtt
 ENV SCANNER_HOME /home/scanner
 RUN mkdir $SCANNER_HOME
 
-COPY . $SCANNER_HOME
-
 RUN groupadd -r scanner \
   && useradd -r -c "Scanner user" -g scanner scanner \
   && chown -R scanner:scanner ${SCANNER_HOME}
@@ -169,3 +167,5 @@ WORKDIR $SCANNER_HOME
 VOLUME /data
 
 ENTRYPOINT ["./scan_wrap.sh"]
+
+COPY . $SCANNER_HOME

--- a/Dockerfile
+++ b/Dockerfile
@@ -125,16 +125,6 @@ ENV PATH /go/bin:$PATH
 # Node
 RUN ln -s /usr/bin/nodejs /usr/bin/node
 
-###
-# ssllabs-scan
-
-RUN mkdir -p /go/src /go/bin \
-      && chmod -R 777 /go
-RUN go get github.com/ssllabs/ssllabs-scan
-RUN cd /go/src/github.com/ssllabs/ssllabs-scan/ \
-      && git checkout stable \
-      && go install
-ENV SSLLABS_PATH /go/bin/ssllabs-scan
 
 ###
 # phantomas
@@ -149,7 +139,12 @@ RUN npm install \
 ###
 # pshtt
 
-RUN pip3 install pshtt==0.2.1
+RUN apt-get install -qq --yes locales
+RUN locale-gen en_US.UTF-8
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US:en
+ENV LC_ALL en_US.UTF-8
+RUN pip3 install pshtt
 
 
 ###

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ pyyaml
 # to support sslyze scanner
 sslyze
 cryptography
+timeout-decorator
 
 # to support censys gatherer
 censys

--- a/scanners/pshtt.py
+++ b/scanners/pshtt.py
@@ -50,7 +50,7 @@ def scan(domain, options):
 
     if (force is False) and (os.path.exists(cache_pshtt)):
         logging.debug("\tCached.")
-        raw = open(cache_pshtt).read()
+        raw = utils.read(cache_pshtt)
         data = json.loads(raw)
         if (data.__class__ is dict) and data.get('invalid'):
             return None

--- a/scanners/sslyze.py
+++ b/scanners/sslyze.py
@@ -5,6 +5,7 @@ import os
 import timeout_decorator
 
 import sslyze
+from sslyze.synchronous_scanner import SynchronousScanner
 from sslyze.concurrent_scanner import ConcurrentScanner, PluginRaisedExceptionScanResult
 from sslyze.plugins.openssl_cipher_suites_plugin import Tlsv10ScanCommand, Tlsv11ScanCommand, Tlsv12ScanCommand, Sslv20ScanCommand, Sslv30ScanCommand
 from sslyze.plugins.certificate_info_plugin import CertificateInfoScanCommand
@@ -22,6 +23,11 @@ from cryptography.hazmat.primitives.asymmetric import ec, dsa, rsa
 #
 # If data exists for a domain from `pshtt`, will check results
 # and only process domains with valid HTTPS, or broken chains.
+#
+# Supported options:
+#
+# --sslyze-serial - If set, will use a synchronous (single-threaded
+#   in-process) scanner. Defaults to false.
 ###
 
 command = os.environ.get("SSLYZE_PATH", "sslyze")
@@ -72,7 +78,7 @@ def scan(domain, options):
             # TODO: timeout not actually enforced, due to issues
             # with multiprocessing.
             # If we have to, we can try single-threading to enforce a timeout.
-            data = run_sslyze(scan_domain)
+            data = run_sslyze(scan_domain, options)
         except timeout_decorator.timeout_decorator.TimeoutError:
             # logging.warn(utils.format_last_exception())
             logging.warn("\tTimeout error (%is) running sslyze." % timeout)
@@ -138,54 +144,17 @@ headers = [
 # Certificate PEM data must be separately parsed using
 # the Python cryptography module.
 
-def run_sslyze(hostname):
-    server_info, scanner = init_sslyze(hostname)
+def run_sslyze(hostname, options):
+    sync = options.get("sslyze-serial", False)
 
-    logging.debug("\t Running scans...")
+    # Initialize either a synchronous or concurrent scanner.
+    server_info, scanner = init_sslyze(hostname, sync)
 
-    # Initialize commands and result containers
-    sslv2, sslv3, tlsv1, tlsv1_1, tlsv1_2 = None, None, None, None, None
-
-    # Queue them all up
-    run_command(Sslv20ScanCommand(), server_info, scanner)
-    run_command(Sslv30ScanCommand(), server_info, scanner)
-    run_command(Tlsv10ScanCommand(), server_info, scanner)
-    run_command(Tlsv11ScanCommand(), server_info, scanner)
-    run_command(Tlsv12ScanCommand(), server_info, scanner)
-    run_command(CertificateInfoScanCommand(), server_info, scanner)
-
-    # Reassign them back to predictable places after they're all done
-    was_error = False
-    for result in scanner.get_results():
-        try:
-            if isinstance(result, PluginRaisedExceptionScanResult):
-                logging.warn(u'Scan command failed: {}'.format(result.as_text()))
-                return None
-
-            if type(result.scan_command) == Sslv20ScanCommand:
-                sslv2 = result
-            elif type(result.scan_command) == Sslv30ScanCommand:
-                sslv3 = result
-            elif type(result.scan_command) == Tlsv10ScanCommand:
-                tlsv1 = result
-            elif type(result.scan_command) == Tlsv11ScanCommand:
-                tlsv1_1 = result
-            elif type(result.scan_command) == Tlsv12ScanCommand:
-                tlsv1_2 = result
-            elif type(result.scan_command) == CertificateInfoScanCommand:
-                certs = result
-            else:
-                logging.warn("\tCouldn't match scan result with command! %s" % result)
-                was_error = True
-
-        except Exception as err:
-            logging.warn("\t Exception inside async scanner result processing.")
-            was_error = True
-            utils.notify(err)
-
-    # There was an error during async processing.
-    if was_error:
-        return None
+    # Whether sync or concurrent, get responses for all scans.
+    if sync:
+        sslv2, sslv3, tlsv1, tlsv1_1, tlsv1_2, certs = scan_serial(scanner, server_info)
+    else:
+        sslv2, sslv3, tlsv1, tlsv1_1, tlsv1_2, certs = scan_parallel(scanner, server_info)
 
     # Parse the results into a dict, which will also be cached as JSON.
     data = {
@@ -344,7 +313,7 @@ def supported_protocol(result):
 
 
 # SSlyze initialization boilerplate
-def init_sslyze(hostname):
+def init_sslyze(hostname, sync=False):
     try:
         server_info = sslyze.server_connectivity.ServerConnectivityInfo(hostname=hostname, port=443)
     except Exception as err:
@@ -362,15 +331,93 @@ def init_sslyze(hostname):
         logging.warn("\tUnknown exception when performing server connectivity info.")
         return None
 
-    scanner = ConcurrentScanner()
+    if sync:
+        scanner = SynchronousScanner()
+    else:
+        scanner = ConcurrentScanner()
 
     return server_info, scanner
 
+# Run each scan in-process, one at a time.
+# Takes longer, but no multi-process funny business.
+def scan_serial(scanner, server_info):
+    logging.debug("\tRunning scans in serial.")
+    logging.debug("\t\tSSLv2 scan.")
+    sslv2 = scanner.run_scan_command(server_info, Sslv20ScanCommand())
+    logging.debug("\t\tSSLv3 scan.")
+    sslv3 = scanner.run_scan_command(server_info, Sslv30ScanCommand())
+    logging.debug("\t\tTLSv1.0 scan.")
+    tlsv1 = scanner.run_scan_command(server_info, Tlsv10ScanCommand())
+    logging.debug("\t\tTLSv1.1 scan.")
+    tlsv1_1 = scanner.run_scan_command(server_info, Tlsv11ScanCommand())
+    logging.debug("\t\tTLSv1.2 scan.")
+    tlsv1_2 = scanner.run_scan_command(server_info, Tlsv12ScanCommand())
+    logging.debug("\t\tCertificate information scan.")
+    certs = scanner.run_scan_command(server_info, CertificateInfoScanCommand())
+    logging.debug("\tDone scanning.")
 
-def run_command(command, server_info, scanner):
-    try:
-        return scanner.queue_scan_command(server_info, command)
-    except Exception as err:
-        utils.notify(err)
-        logging.warn("Unknown exception running sslyze command.")
+    return sslv2, sslv3, tlsv1, tlsv1_1, tlsv1_2, certs
+
+# Run each scan in parallel, using multi-processing.
+# Faster, but can generate many processes.
+def scan_parallel(scanner, server_info):
+    logging.debug("\tRunning scans in parallel.")
+
+    def queue(command):
+        try:
+            return scanner.queue_scan_command(server_info, command)
+        except Exception as err:
+            utils.notify(err)
+            logging.warn("Unknown exception queueing sslyze command.")
+            return None
+
+
+    # Initialize commands and result containers
+    sslv2, sslv3, tlsv1, tlsv1_1, tlsv1_2, certs = None, None, None, None, None, None
+
+    # Queue them all up
+    queue(Sslv20ScanCommand())
+    queue(Sslv30ScanCommand())
+    queue(Tlsv10ScanCommand())
+    queue(Tlsv11ScanCommand())
+    queue(Tlsv12ScanCommand())
+    queue(CertificateInfoScanCommand())
+
+    # Reassign them back to predictable places after they're all done
+    was_error = False
+    for result in scanner.get_results():
+        try:
+            if isinstance(result, PluginRaisedExceptionScanResult):
+                logging.warn(u'Scan command failed: {}'.format(result.as_text()))
+                return None
+
+            if type(result.scan_command) == Sslv20ScanCommand:
+                sslv2 = result
+            elif type(result.scan_command) == Sslv30ScanCommand:
+                sslv3 = result
+            elif type(result.scan_command) == Tlsv10ScanCommand:
+                tlsv1 = result
+            elif type(result.scan_command) == Tlsv11ScanCommand:
+                tlsv1_1 = result
+            elif type(result.scan_command) == Tlsv12ScanCommand:
+                tlsv1_2 = result
+            elif type(result.scan_command) == CertificateInfoScanCommand:
+                certs = result
+            else:
+                logging.warn("\tCouldn't match scan result with command! %s" % result)
+                was_error = True
+
+        except Exception as err:
+            logging.warn("\t Exception inside async scanner result processing.")
+            was_error = True
+            utils.notify(err)
+
+    # There was an error during async processing.
+    if was_error:
         return None
+
+    logging.debug("\tDone scanning.")
+
+    return sslv2, sslv3, tlsv1, tlsv1_1, tlsv1_2, certs
+
+

--- a/scanners/sslyze.py
+++ b/scanners/sslyze.py
@@ -34,6 +34,7 @@ network_timeout = 5
 
 command = os.environ.get("SSLYZE_PATH", "sslyze")
 
+
 def scan(domain, options):
     logging.debug("[%s][sslyze]" % domain)
 
@@ -152,7 +153,7 @@ def run_sslyze(hostname, options):
     # Initialize either a synchronous or concurrent scanner.
     server_info, scanner = init_sslyze(hostname, options, sync=sync)
 
-    if server_info == None:
+    if server_info is None:
         data['errors'] = "Connectivity not established."
         return data
 
@@ -293,6 +294,7 @@ def analyze_certs(certs):
 
     return data['certs']
 
+
 # Given the cert sub-obj from the sslyze JSON, use
 # the cryptography module to parse its PEM contents.
 def parse_cert(cert):
@@ -368,7 +370,7 @@ def scan_serial(scanner, server_info, options):
     tlsv1_2 = scanner.run_scan_command(server_info, Tlsv12ScanCommand())
 
     # Default to cert info on
-    if options.get("sslyze-no-certs", False) == False:
+    if options.get("sslyze-no-certs", False) is False:
         logging.debug("\t\tCertificate information scan.")
         certs = scanner.run_scan_command(server_info, CertificateInfoScanCommand())
     else:
@@ -403,7 +405,7 @@ def scan_parallel(scanner, server_info, options):
     queue(Tlsv12ScanCommand())
 
     # Default to cert info on.
-    if options.get("sslyze-no-certs", False) == False:
+    if options.get("sslyze-no-certs", False) is False:
         queue(CertificateInfoScanCommand())
 
     # Reassign them back to predictable places after they're all done

--- a/scanners/sslyze.py
+++ b/scanners/sslyze.py
@@ -341,6 +341,7 @@ def init_sslyze(hostname, sync=False):
 
     return server_info, scanner
 
+
 # Run each scan in-process, one at a time.
 # Takes longer, but no multi-process funny business.
 def scan_serial(scanner, server_info):
@@ -361,6 +362,7 @@ def scan_serial(scanner, server_info):
 
     return sslv2, sslv3, tlsv1, tlsv1_1, tlsv1_2, certs
 
+
 # Run each scan in parallel, using multi-processing.
 # Faster, but can generate many processes.
 def scan_parallel(scanner, server_info):
@@ -373,7 +375,6 @@ def scan_parallel(scanner, server_info):
             utils.notify(err)
             logging.warn("Unknown exception queueing sslyze command.")
             return None
-
 
     # Initialize commands and result containers
     sslv2, sslv3, tlsv1, tlsv1_1, tlsv1_2, certs = None, None, None, None, None, None
@@ -422,5 +423,3 @@ def scan_parallel(scanner, server_info):
     logging.debug("\tDone scanning.")
 
     return sslv2, sslv3, tlsv1, tlsv1_1, tlsv1_2, certs
-
-

--- a/scanners/sslyze.py
+++ b/scanners/sslyze.py
@@ -2,6 +2,8 @@ import logging
 from scanners import utils
 import os
 
+import timeout_decorator
+
 import json
 import cryptography
 import cryptography.hazmat.backends.openssl
@@ -18,6 +20,14 @@ from cryptography.hazmat.primitives.asymmetric import ec, dsa, rsa
 
 command = os.environ.get("SSLYZE_PATH", "sslyze")
 
+# This timeout is enforced in this file, in Python, not in sslyze.
+timeout = 1
+
+
+# Blocked off the scan command to use a forcible timeout
+@timeout_decorator.timeout(timeout, use_signals=False)
+def actual_scan(scan_args):
+    return utils.scan(scan_args)
 
 def scan(domain, options):
     logging.debug("[%s][sslyze]" % domain)
@@ -59,15 +69,21 @@ def scan(domain, options):
 
         # This is --regular minus --heartbleed
         # See: https://github.com/nabla-c0d3/sslyze/issues/217
-        raw_response = utils.scan([
-            command,
-            "--sslv2", "--sslv3", "--tlsv1", "--tlsv1_1", "--tlsv1_2",
-            "--reneg", "--resum", "--certinfo",
-            "--http_get", "--hide_rejected_ciphers",
-            "--compression", "--openssl_ccs",
-            "--fallback", "--quiet",
-            scan_domain, "--json_out=%s" % cache_json
-        ])
+        raw_response = None
+
+        try:
+            raw_response = actual_scan([
+                command,
+                "--sslv2", "--sslv3", "--tlsv1", "--tlsv1_1", "--tlsv1_2",
+                "--reneg", "--resum", "--certinfo",
+                "--http_get", "--hide_rejected_ciphers",
+                "--compression", "--openssl_ccs",
+                "--fallback", "--quiet",
+                scan_domain, "--json_out=%s" % cache_json
+            ])
+        except timeout_decorator.timeout_decorator.TimeoutError:
+            # logging.warn(utils.format_last_exception())
+            logging.warn("\tTimeout error (%is) running sslyze." % timeout)
 
         if raw_response is None:
             # TODO: save standard invalid JSON data...?

--- a/scanners/sslyze.py
+++ b/scanners/sslyze.py
@@ -212,6 +212,15 @@ def run_sslyze(hostname, options):
 
         data['config']['weakest_dh'] = weakest_dh
 
+    # TODO: do_cert?
+    # data['certs'] = analyze_certs(certs)
+
+    return data
+
+
+def analyze_certs(certs):
+    data = {'certs': {}}
+
     # Served chain.
     served_chain = certs.certificate_chain
 
@@ -272,8 +281,7 @@ def run_sslyze(hostname, options):
     if data['certs'].get('constructed_issuer'):
         data['certs']['any_sha1_constructed'] = certs.has_sha1_in_certificate_chain
 
-    return data
-
+    return data['certs']
 
 # Given the cert sub-obj from the sslyze JSON, use
 # the cryptography module to parse its PEM contents.
@@ -343,8 +351,12 @@ def scan_serial(scanner, server_info):
     tlsv1_1 = scanner.run_scan_command(server_info, Tlsv11ScanCommand())
     logging.debug("\t\tTLSv1.2 scan.")
     tlsv1_2 = scanner.run_scan_command(server_info, Tlsv12ScanCommand())
-    logging.debug("\t\tCertificate information scan.")
-    certs = scanner.run_scan_command(server_info, CertificateInfoScanCommand())
+
+    # TODO: do_cert?
+    # logging.debug("\t\tCertificate information scan.")
+    # certs = scanner.run_scan_command(server_info, CertificateInfoScanCommand())
+    certs = None
+
     logging.debug("\tDone scanning.")
 
     return sslv2, sslv3, tlsv1, tlsv1_1, tlsv1_2, certs
@@ -372,7 +384,8 @@ def scan_parallel(scanner, server_info):
     queue(Tlsv10ScanCommand())
     queue(Tlsv11ScanCommand())
     queue(Tlsv12ScanCommand())
-    queue(CertificateInfoScanCommand())
+    # TODO: do_cert?
+    # queue(CertificateInfoScanCommand())
 
     # Reassign them back to predictable places after they're all done
     was_error = False

--- a/scanners/sslyze.py
+++ b/scanners/sslyze.py
@@ -21,7 +21,7 @@ from cryptography.hazmat.primitives.asymmetric import ec, dsa, rsa
 command = os.environ.get("SSLYZE_PATH", "sslyze")
 
 # This timeout is enforced in this file, in Python, not in sslyze.
-timeout = 1
+timeout = 20
 
 
 # Blocked off the scan command to use a forcible timeout

--- a/scanners/sslyze.py
+++ b/scanners/sslyze.py
@@ -367,8 +367,8 @@ def scan_serial(scanner, server_info, options):
     logging.debug("\t\tTLSv1.2 scan.")
     tlsv1_2 = scanner.run_scan_command(server_info, Tlsv12ScanCommand())
 
-    # Default to cert info off
-    if options.get("sslyze-certs"):
+    # Default to cert info on
+    if options.get("sslyze-no-certs", False) == False:
         logging.debug("\t\tCertificate information scan.")
         certs = scanner.run_scan_command(server_info, CertificateInfoScanCommand())
     else:
@@ -402,8 +402,8 @@ def scan_parallel(scanner, server_info, options):
     queue(Tlsv11ScanCommand())
     queue(Tlsv12ScanCommand())
 
-    # Default to cert info off
-    if options.get("sslyze-certs"):
+    # Default to cert info on.
+    if options.get("sslyze-no-certs", False) == False:
         queue(CertificateInfoScanCommand())
 
     # Reassign them back to predictable places after they're all done

--- a/scanners/sslyze.py
+++ b/scanners/sslyze.py
@@ -30,11 +30,6 @@ command = os.environ.get("SSLYZE_PATH", "sslyze")
 timeout = 20
 
 
-# Blocked off the scan command to use a forcible timeout
-@timeout_decorator.timeout(timeout, use_signals=False)
-def actual_scan(scan_args):
-    return utils.scan(scan_args)
-
 def scan(domain, options):
     logging.debug("[%s][sslyze]" % domain)
 
@@ -76,6 +71,9 @@ def scan(domain, options):
         raw_response = None
 
         try:
+            # TODO: timeout not actually enforced, due to issues
+            # with multiprocessing.
+            # If we have to, we can try single-threading to enforce a timeout.
             data = run_sslyze(scan_domain)
         except timeout_decorator.timeout_decorator.TimeoutError:
             # logging.warn(utils.format_last_exception())

--- a/scanners/sslyze.py
+++ b/scanners/sslyze.py
@@ -2,8 +2,6 @@ import logging
 from scanners import utils
 import os
 
-import timeout_decorator
-
 import sslyze
 from sslyze.synchronous_scanner import SynchronousScanner
 from sslyze.concurrent_scanner import ConcurrentScanner, PluginRaisedExceptionScanResult
@@ -31,10 +29,6 @@ from cryptography.hazmat.primitives.asymmetric import ec, dsa, rsa
 ###
 
 command = os.environ.get("SSLYZE_PATH", "sslyze")
-
-# This timeout is enforced in this file, in Python, not in sslyze.
-timeout = 20
-
 
 def scan(domain, options):
     logging.debug("[%s][sslyze]" % domain)
@@ -74,14 +68,7 @@ def scan(domain, options):
         # use scan_domain (possibly www-prefixed) to do actual scan
         logging.debug("\t %s %s" % (command, scan_domain))
 
-        try:
-            # TODO: timeout not actually enforced, due to issues
-            # with multiprocessing.
-            # If we have to, we can try single-threading to enforce a timeout.
-            data = run_sslyze(scan_domain, options)
-        except timeout_decorator.timeout_decorator.TimeoutError:
-            # logging.warn(utils.format_last_exception())
-            logging.warn("\tTimeout error (%is) running sslyze." % timeout)
+        data = run_sslyze(scan_domain, options)
 
         if data is None:
             # TODO: save standard invalid JSON data...?

--- a/scanners/sslyze.py
+++ b/scanners/sslyze.py
@@ -55,7 +55,7 @@ def scan(domain, options):
 
     if (force is False) and (os.path.exists(cache_json)):
         logging.debug("\tCached.")
-        raw_json = open(cache_json).read()
+        raw_json = utils.read(cache_json)
         try:
             data = json.loads(raw_json)
             if (data.__class__ is dict) and data.get('invalid'):

--- a/scanners/sslyze.py
+++ b/scanners/sslyze.py
@@ -68,8 +68,6 @@ def scan(domain, options):
         # use scan_domain (possibly www-prefixed) to do actual scan
         logging.debug("\t %s %s" % (command, scan_domain))
 
-        raw_response = None
-
         try:
             # TODO: timeout not actually enforced, due to issues
             # with multiprocessing.
@@ -339,13 +337,13 @@ def cert_issuer_name(parsed):
         return None
     return attrs[0].value
 
+
 # Given CipherSuiteScanResult, whether the protocol is supported
 def supported_protocol(result):
     return (len(result.accepted_cipher_list) > 0)
 
 
-## SSlyze boilerplate
-
+# SSlyze initialization boilerplate
 def init_sslyze(hostname):
     try:
         server_info = sslyze.server_connectivity.ServerConnectivityInfo(hostname=hostname, port=443)
@@ -368,6 +366,7 @@ def init_sslyze(hostname):
 
     return server_info, scanner
 
+
 def run_command(command, server_info, scanner):
     try:
         return scanner.queue_scan_command(server_info, command)
@@ -375,4 +374,3 @@ def run_command(command, server_info, scanner):
         utils.notify(err)
         logging.warn("Unknown exception running sslyze command.")
         return None
-

--- a/scanners/sslyze.py
+++ b/scanners/sslyze.py
@@ -316,6 +316,9 @@ def supported_protocol(result):
 def init_sslyze(hostname, sync=False):
     try:
         server_info = sslyze.server_connectivity.ServerConnectivityInfo(hostname=hostname, port=443)
+    except sslyze.server_connectivity.ServerConnectivityError as error:
+        logging.warn("\tServer connectivity not established during initialization.")
+        return None
     except Exception as err:
         utils.notify(err)
         logging.warn("\tUnknown exception when initializing server connectivity info.")
@@ -324,7 +327,7 @@ def init_sslyze(hostname, sync=False):
     try:
         server_info.test_connectivity_to_server()
     except sslyze.server_connectivity.ServerConnectivityError as err:
-        logging.warn("\tServer connectivity not established.")
+        logging.warn("\tServer connectivity not established during test.")
         return None
     except Exception as err:
         utils.notify(err)

--- a/scanners/utils.py
+++ b/scanners/utils.py
@@ -111,6 +111,12 @@ def write(content, destination, binary=False):
     f.close()
 
 
+def read(source):
+    with open(source) as f:
+        contents = f.read()
+    return contents
+
+
 def report_dir():
     return options().get("output", "./")
 
@@ -191,7 +197,7 @@ def cache_single(filename):
 def data_for(domain, operation):
     path = cache_path(domain, operation)
     if os.path.exists(path):
-        raw = open(path).read()
+        raw = read(path)
         data = json.loads(raw)
         if isinstance(data, dict) and (data.get('invalid', False)):
             return None


### PR DESCRIPTION
This is a better approach than #150, which moves us to using sslyze as a Python library rather than shelling out.

It still uses the concurrent scanner, which itself does spin out multiple processes, so this may yet get us into trouble, but it is now easy for us to use the synchronous scanner if we want to, and in general have more control over the parsing experience. 

The timeout library I introduced in #150 can't function with this, as the sslyze native Python calls to do its own multiprocess work interfere with the timeout's multiprocess work when signals are disabled. (When signals are enabled, the timeout library throws an error about sslyze's use of multiple processes. There's no winning.)

If this fails to fix the hanging issues, I'll switch it to use the SynchronousScanner, which will eliminate all use of multiple processes, and we'll get more granular as needed about the root cause.