### PR TITLE
Use third party cache dir flag in pshtt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,6 @@ pyyaml
 # to support sslyze scanner
 sslyze
 cryptography
-timeout-decorator
 
 # to support censys gatherer
 censys

--- a/scanners/pshtt.py
+++ b/scanners/pshtt.py
@@ -2,6 +2,7 @@ import logging
 from scanners import utils
 import os
 import json
+import glob
 
 ###
 # == pshtt ==
@@ -20,22 +21,20 @@ user_agent = os.environ.get("PSHTT_USER_AGENT", "github.com/18f/domain-scan, psh
 
 # save (and look for) preload file in cache/preload-list.json
 # same format as inspect.py uses
-preload_cache = utils.cache_single("preload-list.json")
-
-# save (and look for) preload file in cache/public-suffix-list.json
-public_suffix_cache = utils.cache_single("public-suffix-list.json")
+third_parties_cache = utils.cache_single("pshtt/third_parties")
 
 
 # The preload and public suffix list caches are only important across
 # individual executions of pshtt. They are not intended to be cached across
 # individual executions of domain-scan itself.
 def init(options):
-    if os.path.exists(preload_cache):
-        logging.warn("Clearing cached preload-list.json file before scanning.")
-        os.remove(preload_cache)
-    if os.path.exists(public_suffix_cache):
-        logging.warn("Clearing cached public-suffix-list.json file before scanning.")
-        os.remove(public_suffix_cache)
+
+    if os.path.exists(third_parties_cache):
+        logging.warn("Clearing cached third party pshtt data before scanning.")
+        for path in glob.glob(os.path.join(third_parties_cache, "*")):
+            os.remove(path)
+        os.rmdir(third_parties_cache)
+
     return True
 
 
@@ -64,8 +63,7 @@ def scan(domain, options):
             '--json',
             '--user-agent', '\"%s\"' % user_agent,
             '--timeout', str(timeout),
-            '--preload-cache', preload_cache,
-            '--suffix-cache', public_suffix_cache
+            '--cache-third-parties', third_parties_cache
         ])
 
         if not raw:

--- a/scanners/sslyze.py
+++ b/scanners/sslyze.py
@@ -32,6 +32,7 @@ from cryptography.hazmat.primitives.asymmetric import ec, dsa, rsa
 # Not much patience here, and very willing to move on.
 network_timeout = 5
 
+
 def scan(domain, options):
     logging.debug("[%s][sslyze]" % domain)
 


### PR DESCRIPTION
This PR makes use of the `--cache-third-parties` flag that is proposed to be added in https://github.com/dhs-ncats/pshtt/pull/131. 

This PR shouldn't be merged until/unless that one is merged, and if any changes are made to https://github.com/dhs-ncats/pshtt/pull/131, I'll need to reflect them here before merging.