### PR TITLE
docker-compose and Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,6 @@ MAINTAINER V. David Zvenyach <vladlen.zvenyach@gsa.gov>
 ###
 # Dependencies
 ###
-
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN \
@@ -48,34 +47,22 @@ RUN \
       # Additional dependencies for python-build
       libbz2-dev \
       llvm \
-      libncursesw5-dev
-
-RUN apt-get install \
-      -qq \
-      --yes \
-      --no-install-recommends \
-      --no-install-suggests \
+      libncursesw5-dev \
+      # Not sure what these dependencies are for
       nodejs \
       npm
 
-    # Clean up packages.
-RUN apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
-
-
 ###
 ## Python
-
-ENV PYENV_RELEASE 1.1.1
-ENV PYENV_PYTHON_VERSION 3.6.1
-ENV PYENV_ROOT /opt/pyenv
-ENV PYENV_REPO https://github.com/pyenv/pyenv
+###
+ENV PYENV_RELEASE=1.1.1 PYENV_PYTHON_VERSION=3.6.1 PYENV_ROOT=/opt/pyenv \
+    PYENV_REPO=https://github.com/pyenv/pyenv
 
 RUN wget ${PYENV_REPO}/archive/v${PYENV_RELEASE}.zip \
       --no-verbose \
-  && unzip v$PYENV_RELEASE.zip -d $PYENV_ROOT \
-  && mv $PYENV_ROOT/pyenv-$PYENV_RELEASE/* $PYENV_ROOT/ \
-  && rm -r $PYENV_ROOT/pyenv-$PYENV_RELEASE
+    && unzip v$PYENV_RELEASE.zip -d $PYENV_ROOT \
+    && mv $PYENV_ROOT/pyenv-$PYENV_RELEASE/* $PYENV_ROOT/ \
+    && rm -r $PYENV_ROOT/pyenv-$PYENV_RELEASE
 
 #
 # Uncomment these lines if you just want to install python...
@@ -94,78 +81,71 @@ RUN echo 'eval "$(pyenv init -)"' >> /etc/profile \
     && eval "$(pyenv init -)" \
     && pyenv install --debug --keep $PYENV_PYTHON_VERSION \
     && pyenv local ${PYENV_PYTHON_VERSION}-debug
-RUN ln -s /opt/pyenv/sources/${PYENV_PYTHON_VERSION}-debug/Python-${PYENV_PYTHON_VERSION}/python-gdb.py /opt/pyenv/versions/${PYENV_PYTHON_VERSION}-debug/bin/python3.6-gdb.py
-RUN ln -s /opt/pyenv/sources/${PYENV_PYTHON_VERSION}-debug/Python-${PYENV_PYTHON_VERSION}/python-gdb.py /opt/pyenv/versions/${PYENV_PYTHON_VERSION}-debug/bin/python3-gdb.py
-RUN ln -s /opt/pyenv/sources/${PYENV_PYTHON_VERSION}-debug/Python-${PYENV_PYTHON_VERSION}/python-gdb.py /opt/pyenv/versions/${PYENV_PYTHON_VERSION}-debug/bin/python-gdb.py
-RUN apt-get -qq update && \
-    apt-get -qq --yes --no-install-recommends --no-install-suggests install gdb
-RUN echo add-auto-load-safe-path /opt/pyenv/sources/${PYENV_PYTHON_VERSION}-debug/Python-${PYENV_PYTHON_VERSION}/ >> etc/gdb/gdbinit
+RUN ln -s /opt/pyenv/sources/${PYENV_PYTHON_VERSION}-debug/Python-${PYENV_PYTHON_VERSION}/python-gdb.py \
+    /opt/pyenv/versions/${PYENV_PYTHON_VERSION}-debug/bin/python3.6-gdb.py \
+    && ln -s /opt/pyenv/sources/${PYENV_PYTHON_VERSION}-debug/Python-${PYENV_PYTHON_VERSION}/python-gdb.py \
+    /opt/pyenv/versions/${PYENV_PYTHON_VERSION}-debug/bin/python3-gdb.py \
+    && ln -s /opt/pyenv/sources/${PYENV_PYTHON_VERSION}-debug/Python-${PYENV_PYTHON_VERSION}/python-gdb.py \
+    /opt/pyenv/versions/${PYENV_PYTHON_VERSION}-debug/bin/python-gdb.py
+RUN apt-get -qq --yes --no-install-recommends --no-install-suggests install gdb
+RUN echo add-auto-load-safe-path \
+    /opt/pyenv/sources/${PYENV_PYTHON_VERSION}-debug/Python-${PYENV_PYTHON_VERSION}/ \
+    >> etc/gdb/gdbinit
 
 COPY requirements.txt requirements.txt
-RUN pip3 install --upgrade pip
-RUN pip3 install --upgrade setuptools
-RUN pip3 install -r requirements.txt
+RUN pip3 install --upgrade pip \
+    && pip3 install --upgrade setuptools \
+    && pip3 install -r requirements.txt
 
 ###
 # Go
-
-ENV GOLANG_VERSION 1.8.3
-
-
+###
+ENV GOLANG_VERSION=1.8.3 PATH=/go/bin:/usr/src/go/bin:$PATH GOPATH=/go \
+    GOROOT=/usr/src/go
 
 RUN curl -sSL https://storage.googleapis.com/golang/go${GOLANG_VERSION}.linux-amd64.tar.gz \
     | tar -v -C /usr/src -xz
 
-ENV PATH /usr/src/go/bin:$PATH
-ENV GOPATH /go
-ENV GOROOT /usr/src/go
-ENV PATH /go/bin:$PATH
-
 ###
 # Node
+###
 RUN ln -s /usr/bin/nodejs /usr/bin/node
-
 
 ###
 # phantomas
-
-RUN npm install \
-      --global \
-    phantomas \
-    phantomjs-prebuilt \
-    es6-promise@3.1.2 \
-    pa11y@3.0.1
+###
+RUN npm install --global phantomas phantomjs-prebuilt \
+    es6-promise@3.1.2 pa11y@3.0.1
 
 ###
 # pshtt
-
-RUN apt-get install -qq --yes locales
-RUN locale-gen en_US.UTF-8
-ENV LANG en_US.UTF-8
-ENV LANGUAGE en_US:en
-ENV LC_ALL en_US.UTF-8
+###
+RUN apt-get install -qq --yes locales && locale-gen en_US.UTF-8
+ENV LANG=en_US.UTF-8 LANGUAGE=en_US:en LC_ALL=en_US.UTF-8
 RUN pip3 install pshtt
 
 
 ###
 # Create unprivileged User
-
+###
 ENV SCANNER_HOME /home/scanner
-RUN mkdir $SCANNER_HOME
-
-RUN groupadd -r scanner \
-  && useradd -r -c "Scanner user" -g scanner scanner \
-  && chown -R scanner:scanner ${SCANNER_HOME}
+RUN mkdir $SCANNER_HOME \
+    && groupadd -r scanner \
+    &&  useradd -r -c "Scanner user" -g scanner scanner \
+    && chown -R scanner:scanner ${SCANNER_HOME}
 
 
 ###
 # Prepare to Run
-
+###
 WORKDIR $SCANNER_HOME
 
 # Volume mount for use with the 'data' option.
 VOLUME /data
 
 ENTRYPOINT ["./scan_wrap.sh"]
+
+# Clean up aptitude stuff we no longer need
+RUN apt-get clean && rm -rf /var/lib/apt/lists/*
 
 COPY . $SCANNER_HOME

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,14 @@
-scan:
-  env_file: .env
-  build: .
-  volumes:
-    - ./:/home/scanner
+version: '3.3'
+
+services:
+  scan:   
+    build: .
+    volumes:
+      - .:/home/scanner
+    # Some internet providers intercept NXDOMAIN and show a search
+    # page instead.  Google's DNS does not, so I prefer to use it.
+    dns:
+      - 8.8.8.8
+    # This is used when debugging with GDB
+    cap_add:
+      - SYS_PTRACE


### PR DESCRIPTION
* `docker-compose.yml`
  * The command `docker-compose build scan` will now build the Docker image.
  * `domain-scan` can be run via a command like `docker-compose run --rm scan scanme.csv --scan=sslyze --serial --debug --force`.
  * No longer fails due to missing `env` directory
* `Dockerfile`
  *  Combined some repetitive lines so that there are fewer layers in the Docker image.  This results in slightly faster builds, slightly smaller images, and most importantly a `Dockerfile` that is a little easier to understand.