### PR TITLE
Eliminate sslyze deadlocks using forkserver

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,6 @@ pyyaml
 # to support sslyze scanner
 sslyze
 cryptography
-timeout-decorator
 
 # to support censys gatherer
 censys

--- a/scan
+++ b/scan
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 
+import multiprocessing
 import os
 import sys
 import glob
@@ -175,4 +176,10 @@ def domains_from(arg):
 
 
 if __name__ == '__main__':
+
+    # Makes it safer for multi-threaded executions of domain-scan
+    # to make use of the multiprocessing module without causing
+    # deadlocks.
+    multiprocessing.set_start_method('forkserver')
+
     run(options)


### PR DESCRIPTION
This sets a `domain-scan`-wide use of `forkserver` for any library-initiated use of the Python `multiprocessing` module to fork processes. This creates a sort of master vanilla process that subsequent process forking will use to generate child processes, rather than the calling process. This should resolve #157.

This should work well for us. [The docs for this approach](https://docs.python.org/3/library/multiprocessing.html#contexts-and-start-methods) say "set_start_method() should not be used more than once in the program." It also provides `get_context()` as an alternative, but that has to happen in library-level code, where as set_start_method can be used in app-layer code. The docs also say "A library which wants to use a particular start method should probably use get_context() to avoid interfering with the choice of the library user."

Some tradeoffs of this approach:

* If dependencies use `multiprocessing`, and they set their own start method without properly using `get_context()`, that could interfere with this one.
* The processes are a little trickier to understand when viewed in `ps`. There's the main called process, then a near-empty forkserver master process, and then also a child of that forkserver process which appears to be the template from which children are spawned. Killing the main called process does not automatically lead to the death of all generated children, and so multiple `kill` or `killall` statements may be necessary if the processes have to be cleaned up.

Fixes #157. (I think.) Held open until a full bulk scan is completed using this branch, and no deadlocks are observed.