### PR TITLE
Adding STARTTLS-related fields to the domain-scan trustymail output

### DIFF
--- a/scanners/trustymail.py
+++ b/scanners/trustymail.py
@@ -49,7 +49,7 @@ def scan(domain, options):
         data = json.loads(raw)
         utils.write(utils.json_for(data), utils.cache_path(domain, "trustymail"))
 
-    # trustymail scanner follows pshtt in  using JSON arrays, even for single items
+    # trustymail scanner follows pshtt in using JSON arrays, even for single items
     data = data[0]
 
     row = []
@@ -62,9 +62,13 @@ def scan(domain, options):
 
 
 headers = [
-    "Live", "MX Record", "Mail Servers",
+    "Live",
+    "MX Record", "Mail Servers", "Mail Server Ports Tested",
+    "Domain Supports SMTP", "Domain Supports SMTP Results",
+    "Domain Supports STARTTLS", "Domain Supports STARTTLS Results",
     "SPF Record", "Valid SPF", "SPF Results",
     "DMARC Record", "Valid DMARC", "DMARC Results",
-    "DMARC Record on Base Domain", "Valid DMARC Record on Base Domain", "DMARC Results on Base Domain", "DMARC Policy",
+    "DMARC Record on Base Domain", "Valid DMARC Record on Base Domain",
+    "DMARC Results on Base Domain", "DMARC Policy",
     "Syntax Errors"
 ]

--- a/scanners/trustymail.py
+++ b/scanners/trustymail.py
@@ -72,5 +72,5 @@ headers = [
     "DMARC Record", "Valid DMARC", "DMARC Results",
     "DMARC Record on Base Domain", "Valid DMARC Record on Base Domain",
     "DMARC Results on Base Domain", "DMARC Policy",
-    "Syntax Errors"
+    "Syntax Errors", "Errors"
 ]

--- a/scanners/trustymail.py
+++ b/scanners/trustymail.py
@@ -39,6 +39,8 @@ def scan(domain, options):
             domain,
             '--json',
             '--timeout', str(timeout),
+            # Use Google DNS
+            '--dns-hostnames', '8.8.8.8,8.8.4.4'
         ])
 
         if not raw:


### PR DESCRIPTION
* Added STARTTLS-related fields to [dhs-ncats/trustymail](https://github.com/dhs-ncats/trustymail) output
* Forcing the use of Google DNS with [dhs-ncats/trustymail](https://github.com/dhs-ncats/trustymail)
* Added the "Errors" field from the [dhs-ncats/trustymail](https://github.com/dhs-ncats/trustymail) output.  This information is useful to have when reconstructing why [dhs-ncats/trustymail](https://github.com/dhs-ncats/trustymail) reached the conclusions it did.  **Note that this also makes this pull request dependent on [pull request 25 from dhs-ncats/trustymail](https://github.com/dhs-ncats/trustymail/pull/25), since it relies on dhs-ncats/trustymail@6d750b77326844850ac01677fa3a66e8d604edf4.**