### PR TITLE
Rapid7 RDNS domain gathererer

### DIFF
--- a/gatherers/rdns.py
+++ b/gatherers/rdns.py
@@ -1,0 +1,36 @@
+from scanners import utils
+import json
+import logging
+
+# Reverse DNS
+#
+# Given a path to a (local) "JSON Lines" formatted file,
+# based on Rapid7's Reverse DNS data, pull out the domains
+# that match the given suffixes.
+#
+# Bearing in mind that the gathering system currently loads
+# all domains into memory in order to dedupe them, it may be
+# easiest to use this on a file that has been pre-filtered in
+# some way (such as by grepping for the intended suffix).
+
+def gather(suffix, options, extra={}):
+    path = options.get("rdns")
+
+    if path is None:
+        logging.warn("--rdns is required to be a path to a local file.")
+        exit(1)
+
+    # May become useful to allow URLs in future.
+    if path.startswith("http:") or path.startswith("https:"):
+        logging.warn("--rdns is required to be a path to a local file.")
+        exit(1)
+
+    with open(path) as lines:
+        logging.debug("\tReading %s..." % path)
+
+        for line in lines:
+            record = json.loads(line)
+            # logging.debug("\t%s" % record["value"])
+            yield record["value"]
+
+

--- a/gatherers/rdns.py
+++ b/gatherers/rdns.py
@@ -1,6 +1,6 @@
-from scanners import utils
 import json
 import logging
+
 
 # Reverse DNS
 #
@@ -32,5 +32,3 @@ def gather(suffix, options, extra={}):
             record = json.loads(line)
             # logging.debug("\t%s" % record["value"])
             yield record["value"]
-
-


### PR DESCRIPTION
This adds as mall gatherer designed to process the [Rapid7 Reverse DNS (v2)](https://scans.io/study/sonar.rdns_v2) scan data. It's basically just a JSON Lines processor, which knows that the domain is in the `value` field of each JSON object.

For reference: the complete unzipped data for an RDNS scan is well over 100GB. I'm currently using this gatherer in a one-off capacity, with a pre-filtered version of the data that's been `grep`-ped down to just lines containing `.gov"` (including the quote to ensure it's the end of the string), which brings it down to ~300MB. However, this gatherer should stream the gathering process line by line and never load the entire file into memory at any point either way.