### PR TITLE
Add a couple noise filters to the Reverse DNS gatherer

### DIFF
--- a/gatherers/rdns.py
+++ b/gatherers/rdns.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import re
 
 
 # Reverse DNS
@@ -12,6 +13,11 @@ import logging
 # all domains into memory in order to dedupe them, it may be
 # easiest to use this on a file that has been pre-filtered in
 # some way (such as by grepping for the intended suffix).
+
+# Best-effort filter for hostnames which are just reflected IPs.
+# IP addresses often use dots or dashes.
+# Some also start with "u-" before the IP address.
+ip_filter = re.compile("^(u-)?\d+[\-\.]\d+[\-\.]\d+[\-\.]\d+")
 
 def gather(suffixes, options, extra={}):
     path = options.get("rdns")
@@ -31,4 +37,7 @@ def gather(suffixes, options, extra={}):
         for line in lines:
             record = json.loads(line)
             # logging.debug("\t%s" % record["value"])
-            yield record["value"]
+
+            # Filter out IP-like reflected addresses.
+            if ip_filter.search(record["value"]) is None:
+                yield record["value"]

--- a/gatherers/rdns.py
+++ b/gatherers/rdns.py
@@ -2,8 +2,6 @@ import json
 import logging
 import re
 
-from scanners import utils
-
 # Reverse DNS
 #
 # Given a path to a (local) "JSON Lines" formatted file,
@@ -24,6 +22,7 @@ ip_filter = re.compile("^(\w+[\-\.]?)?\d+[\-\.]\d+[\-\.]\d+[\-\.]\d+")
 # (Note: this won't work for fed.us subdomains, but that's okay, this
 # is just a best-effort to cut down noise.)
 number_filter = re.compile("^[\d\-]+\.")
+
 
 def gather(suffixes, options, extra={}):
     path = options.get("rdns")

--- a/lambda/deploy
+++ b/lambda/deploy
@@ -67,7 +67,7 @@ if [ "$IS_CREATE" == "--create" ]; then
     --role $AWS_LAMBDA_ROLE \
     --handler lambda_handler.handler \
     --runtime python3.6 \
-    --timeout 30 \
+    --timeout 300 \
     --memory-size 128
 
 # Or, update the function's code with the latest zipped code.

--- a/scanners/utils.py
+++ b/scanners/utils.py
@@ -247,7 +247,9 @@ def just_microseconds(duration):
     return "%.6f" % duration
 
 
-# return base domain for a subdomain
+# Return base domain for a subdomain
+# This *is not* PSL-aware, and will not be correct for domains
+# that use a public suffix (such as fs.fed.us).
 def base_domain_for(subdomain):
     return str.join(".", subdomain.split(".")[-2:])
 


### PR DESCRIPTION
This adds a couple basic filters for IP-reflected or almost completely numerical hostnames in the reverse DNS data. While we might miss a few legit hostnames with this filter, the quality improvement is significant. 

This brings the set of _deduplicated_, _federal_ .gov and .fed.us hostnames from [Rapid7's Reverse DNS v2 dataset](https://scans.io/study/sonar.rdns_v2) from 2.7M down to 350K.