### PR TITLE
Default to serial processing for sslyze, and ditch forkserver

### DIFF
--- a/scan
+++ b/scan
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
 
-import multiprocessing
 import os
 import uuid
 import sys
@@ -579,10 +578,4 @@ def fetch_lambda_details(dict_row):
     return lambda_fields
 
 if __name__ == '__main__':
-
-    # Makes it safer for multi-threaded executions of domain-scan
-    # to make use of the multiprocessing module without causing
-    # deadlocks.
-    multiprocessing.set_start_method('forkserver')
-
     run(options)


### PR DESCRIPTION
After a lot of effort, I'm abandoning the use of `multiprocessing` and its `forkserver` mode for SSLyze. I've never been able to get rid of deadlocks, so I'd rather deal with potential memory issues instead.

This yanks out the `forkserver` switch in `./scan`, and defaults the `sslyze` scanner to serial operation (and requires it in Lambda mode). The parallel scanner code is there and can be enabled, but is not recommended.