### PR TITLE
Incorporate PSL into domain gathering and scanning

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,9 @@
 ipython
 requests
 
+# Use PSL to determine base domains.
+publicsuffix
+
 # Used by all local and Lambda-based code.
 strict-rfc3339
 

--- a/scanners/utils.py
+++ b/scanners/utils.py
@@ -12,10 +12,12 @@ import logging
 import datetime
 import strict_rfc3339
 import codecs
+from urllib.error import URLError
 
 import publicsuffix
 # global in-memory cache
 suffix_list = None
+
 
 # Wrapper to a run() method to catch exceptions.
 def run(run_method, additional=None):
@@ -272,7 +274,6 @@ def base_domain_for(subdomain):
 
 # Returns an instantiated PublicSuffixList object, and the
 # list of lines read from the file.
-from urllib.error import URLError
 def load_suffix_list():
 
     cached_psl = cache_single("public-suffix-list.txt")


### PR DESCRIPTION
This PR adds proper non-naive base domain calculation, using the Public Suffix List, to domain gathering and scanning.

Previously, this was causing us problems with the `.fed.us` domain space, where we were incorrectly listing `fed.us` as the base domain for `fs.fed.us`.