### PR TITLE
The --dns-hostnames option in trustymail was renamed to --dns

### DIFF
--- a/scanners/trustymail.py
+++ b/scanners/trustymail.py
@@ -21,7 +21,7 @@ def scan(domain, environment, options):
         '--json',
         '--timeout', str(timeout),
         # Use Google DNS
-        '--dns-hostnames', '8.8.8.8,8.8.4.4'
+        '--dns', '8.8.8.8,8.8.4.4'
     ]
 
     if options.get("debug", False):


### PR DESCRIPTION
It is used in `domain-scan`, so it also needs to be changed here.