### PR TITLE
Renamed error trustymail output field

### DIFF
--- a/scanners/trustymail.py
+++ b/scanners/trustymail.py
@@ -59,5 +59,5 @@ headers = [
     "DMARC Record", "Valid DMARC", "DMARC Results",
     "DMARC Record on Base Domain", "Valid DMARC Record on Base Domain",
     "DMARC Results on Base Domain", "DMARC Policy",
-    "Syntax Errors", "Errors"
+    "Syntax Errors", "Debug"
 ]


### PR DESCRIPTION
The `trustymail` output field called "Error" was renamed to "Debug".  This requires a change in `domain-scan` as well.

This pull request should be merged once dhs-ncats/trustymail#35 is merged.