### PR TITLE
support mixing lambda and non lambda scanners

### DIFF
--- a/scan
+++ b/scan
@@ -22,6 +22,7 @@ from scanners import utils
 # basic setup - logs, output dirs
 options = utils.options()
 domain_suffix = options.get("suffix")
+lambda_mode = options.get("lambda", False)
 utils.configure_logging(options)
 utils.mkdir_p(utils.cache_dir())
 utils.mkdir_p(utils.results_dir())
@@ -36,11 +37,6 @@ start_command = str.join(" ", sys.argv)
 
 # Generate a random UUID for the entire scan.
 scan_uuid = str(uuid.uuid4())
-
-# Whitelist of scanners that can use lambda
-# (facilitates running a mix of lambda / non-lambda scanners together)
-lambda_supported = ["pshtt", "sslyze"]
-lambda_mode = options.get("lambda", False)
 
 # AWS credentials should be set externally (disk, env, IAMs, etc.).
 if lambda_mode:
@@ -154,10 +150,13 @@ def scan_domains(scanners, domains, options):
     handles = {}
     for scanner in scanners:
         name = scanner.__name__.split(".")[-1]  # e.g. 'pshtt'
-        use_lambda = lambda_mode and name in lambda_supported
         scanner_filename = "%s/%s.csv" % (utils.results_dir(), name)
         scanner_file = open(scanner_filename, 'w', newline='')
         scanner_writer = csv.writer(scanner_file)
+
+        use_lambda = lambda_mode and \
+            hasattr(scanner, "lambda_support") and \
+            scanner.lambda_support
 
         # Write the header row, factoring in Lambda detail if needed.
         headers = prefix_headers + scanner.headers

--- a/scan
+++ b/scan
@@ -37,8 +37,13 @@ start_command = str.join(" ", sys.argv)
 # Generate a random UUID for the entire scan.
 scan_uuid = str(uuid.uuid4())
 
+# Whitelist of scanners that can use lambda
+# (facilitates running a mix of lambda / non-lambda scanners together)
+lambda_supported = ["pshtt", "sslyze"]
+lambda_mode = options.get("lambda", False)
+
 # AWS credentials should be set externally (disk, env, IAMs, etc.).
-if options.get("lambda", False):
+if lambda_mode:
     invoke_config = botocore.config.Config(
         max_pool_connections=global_max_workers,
         connect_timeout=300, read_timeout=300
@@ -141,9 +146,6 @@ def scan_domains(scanners, domains, options):
     for result in glob.glob("%s/*.csv" % utils.results_dir()):
         os.remove(result)
 
-    # Trigger the Lambda pipeline.
-    use_lambda = options.get("lambda", False)
-
     # Store local errors/timing info, and if using Lambda, trigger the
     # Lambda post-processing pipeline to get Lambda timing/usage info.
     meta = options.get("meta", False)
@@ -152,6 +154,7 @@ def scan_domains(scanners, domains, options):
     handles = {}
     for scanner in scanners:
         name = scanner.__name__.split(".")[-1]  # e.g. 'pshtt'
+        use_lambda = lambda_mode and name in lambda_supported
         scanner_filename = "%s/%s.csv" % (utils.results_dir(), name)
         scanner_file = open(scanner_filename, 'w', newline='')
         scanner_writer = csv.writer(scanner_file)
@@ -174,7 +177,8 @@ def scan_domains(scanners, domains, options):
             'file': scanner_file,
             'filename': scanner_filename,
             'writer': scanner_writer,
-            'headers': headers
+            'headers': headers,
+            'use_lambda': use_lambda,
         }
 
     # Initialize all scanner-specific environments.
@@ -182,10 +186,10 @@ def scan_domains(scanners, domains, options):
     # such as data from third-party network sources.
     # Checked now, so that failure can immediately halt the whole scan.
     for scanner in scanners:
-        environment = {}
-
-        environment['scan_method'] = {True: 'lambda', False: 'local'}[use_lambda]
-        environment['scan_uuid'] = scan_uuid
+        environment = {
+            'scan_method': 'lambda' if handles[scanner]['use_lambda'] else 'local',
+            'scan_uuid': scan_uuid,
+        }
 
         # Select workers here, so that it can be passed to the
         # init function.
@@ -242,7 +246,8 @@ def scan_domains(scanners, domains, options):
     # Close up all the files, --sort if requested (memory-expensive).
     # Also fetch Lambda info if requested (time-expensive).
 
-    get_lambda_details = meta and use_lambda and options.get("lambda-details", False)
+    lambda_used = any(handles[scanner]['use_lambda'] for scanner in scanners)
+    get_lambda_details = meta and lambda_used and options.get("lambda-details", False)
 
     # Sleeping's not ideal, but no better idea right now.
     if get_lambda_details:

--- a/scanners/pshtt.py
+++ b/scanners/pshtt.py
@@ -17,6 +17,7 @@ user_agent = "github.com/18f/domain-scan, pshtt.py"
 suffix_list = None
 
 # In Lambda, we package a snapshot of the PSL with the environment.
+lambda_support = True
 lambda_suffix_path = "./public-suffix-list.txt"
 
 

--- a/scanners/sslyze.py
+++ b/scanners/sslyze.py
@@ -31,6 +31,9 @@ from cryptography.hazmat.primitives.asymmetric import ec, dsa, rsa
 # Not much patience here, and very willing to move on.
 network_timeout = 5
 
+# Advertise Lambda support
+lambda_support = True
+
 
 # If we have pshtt data, use it to skip some domains, and to adjust
 # scan hostnames to canonical URLs where we can.


### PR DESCRIPTION
This addresses https://github.com/18F/domain-scan/issues/163, allowing one to use `--lambda` for scanners set up for it, and local otherwise.

It adds a `lambda_supported` scanner whitelist which drives a per-scanner `use_lambda` flag.