### PR TITLE
Renamed "Debug" to "Debug Info"

### DIFF
--- a/scanners/trustymail.py
+++ b/scanners/trustymail.py
@@ -59,5 +59,5 @@ headers = [
     "DMARC Record", "Valid DMARC", "DMARC Results",
     "DMARC Record on Base Domain", "Valid DMARC Record on Base Domain",
     "DMARC Results on Base Domain", "DMARC Policy",
-    "Syntax Errors", "Debug"
+    "Syntax Errors", "Debug Info"
 ]


### PR DESCRIPTION
The "Debug" output column has been renamed "Debug Info" in trustymail, so it needs to be renamed here too.