### PR TITLE
Support AWS named profiles, if one is given, via --aws-profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ Once configured, scans can be run in Lambda using the `--lambda` flag, like so:
 * `--cache` - Use previously cached scan data to avoid scans hitting the network where possible.
 * `--suffix` - Add a suffix to all input domains. For example, a `--suffix` of `virginia.gov` will add `.virginia.gov` to the end of all input domains.
 * `--lambda` - Run certain scanners inside Amazon Lambda instead of locally. (See [the Lambda instructions](docs/lambda.md) for how to use this.)
+* `--aws-profile` - When running Lambda-related commands, use a specified AWS named profile. Credentials/config for this named profile should already be configured separately in the execution environment.
 * `--meta` - Append some additional columns to each row with information about the scan itself. This includes start/end times and durations, as well as any encountered errors. When using `--lambda`, additional Lambda-specific information will be appended.
 
 ### Output

--- a/scan
+++ b/scan
@@ -40,17 +40,25 @@ scan_uuid = str(uuid.uuid4())
 
 # AWS credentials should be set externally (disk, env, IAMs, etc.).
 if lambda_mode:
+    # support AWS named profiles
+    aws_profile = options.get("aws-profile", None)
+    if aws_profile:
+        lambda_session = boto3.session.Session(profile_name=aws_profile)
+    else:
+        lambda_session = boto3.session.Session()
+
     invoke_config = botocore.config.Config(
         max_pool_connections=global_max_workers,
         connect_timeout=300, read_timeout=300
     )
-    invoke_client = boto3.client('lambda', config=invoke_config)
+    invoke_client = lambda_session.client('lambda', config=invoke_config)
+
     # hack to disable automatic retries for Lambda invocations
     # https://github.com/boto/boto3/issues/1104
     invoke_client.meta.events._unique_id_handlers['retry-config-lambda']['handler']._checker.__dict__['_max_attempts'] = 0
 
     logs_config = botocore.config.Config(max_pool_connections=global_max_workers)
-    logs_client = boto3.client('logs', config=logs_config)
+    logs_client = lambda_session.client('logs', config=logs_config)
 
 # Fields that will always get prefixed before scan-specific data.
 prefix_headers = ["Domain", "Base Domain"]


### PR DESCRIPTION
This adds an `--aws-profile` CLI flag, to allow the use of an [AWS named profile](https://docs.aws.amazon.com/cli/latest/userguide/cli-multiple-profiles.html). AWS named profiles are useful when the same execution environment may wish to use different AWS regions/roles/credentials for different commands. 

This is the case for GSA's current Pulse implementation (where S3 backup is in a cloud.gov-managed bucket, but Lambda functions are managed in a separate account).