### PR TITLE
Send in a copy of environment dict to scanner's init_domain hook

### DIFF
--- a/scan
+++ b/scan
@@ -5,6 +5,7 @@ import uuid
 import sys
 import glob
 import time
+import copy
 import datetime
 import logging
 import requests
@@ -211,6 +212,7 @@ def scan_domains(scanners, domains, options):
         environment['workers'] = min(workers, global_max_workers)
 
         if hasattr(scanner, "init"):
+            # pass in 'environment' dict by reference, mutate in-place
             init = scanner.init(environment, options)
 
             # If a scanner's init() function returns false, stop entirely.
@@ -302,7 +304,9 @@ def perform_scan(params):
         # Init function per-domain (always run locally).
         scan_environment = {}
         if hasattr(scanner, "init_domain"):
-            scan_environment = scanner.init_domain(domain, environment, options)
+            # pass in copy of 'environment' dict, any changes should be per-domain
+            environment_copy = copy.deepcopy(environment)
+            scan_environment = scanner.init_domain(domain, environment_copy, options)
 
         # Rely on scanner to say why.
         if scan_environment is False:


### PR DESCRIPTION
domain-scan has been passing the `environment` dict into each scanner's per-domain `init_domain` hook by reference, which caused changes made for one domain to affect subsequent domains during the scanning process. While mutating the `environment` dict in-place is desired for the `init` hook, this is not what we want for the `init_domain` hook, where the environment should only be modified for that specific scan.

This fixes a bug in calculating the preload state of domains when there are 2 or more domains being scanned. However, the bug was more general, and could have affected more scanners and situations than just this one.