### PR TITLE
Fixed bug that made Lambda zips twice as large as they needed to be

### DIFF
--- a/lambda/deploy
+++ b/lambda/deploy
@@ -47,10 +47,12 @@ if [ -f ../envs/$SCANNER_NAME.zip ]; then
   echo "Incorporating custom-built env for $SCANNER_NAME..."
   cp ../envs/$SCANNER_NAME.zip .
   unzip -q $SCANNER_NAME.zip
+  rm $SCANNER_NAME.zip
 else
   echo "Incorporating domain-scan env..."
   cp ../envs/domain-scan.zip .
   unzip -q domain-scan.zip
+  rm domain-scan.zip
 fi
 
 echo "Building zip package for $FUNCTION_NAME..."


### PR DESCRIPTION
Because the environment zip files were being left in the build directory, the resulting `test_<function>.zip` files were about twice as big as they needed to be.  I added a line to delete the environment zip files after they are extracted.