### PR TITLE
Added AWS Lambda support for trustymail

### DIFF
--- a/lambda/deploy
+++ b/lambda/deploy
@@ -47,10 +47,12 @@ if [ -f ../envs/$SCANNER_NAME.zip ]; then
   echo "Incorporating custom-built env for $SCANNER_NAME..."
   cp ../envs/$SCANNER_NAME.zip .
   unzip -q $SCANNER_NAME.zip
+  rm $SCANNER_NAME.zip
 else
   echo "Incorporating domain-scan env..."
   cp ../envs/domain-scan.zip .
   unzip -q domain-scan.zip
+  rm domain-scan.zip
 fi
 
 echo "Building zip package for $FUNCTION_NAME..."

--- a/lambda/remote_build.sh
+++ b/lambda/remote_build.sh
@@ -5,14 +5,16 @@
 #########################################
 
 # System deps.
-sudo yum install python36 python36-virtualenv
-sudo yum install sqlite-devel gcc libffi-devel openssl-devel
-sudo yum install git
+sudo yum install python36 python36-virtualenv \
+     sqlite-devel gcc libffi-devel openssl-devel \
+     git wget zip
 
 # domain-scan isn't in PyPi.
 git clone https://github.com/18F/domain-scan
 # pshtt is in PyPi, but often lags behind.
 git clone https://github.com/dhs-ncats/pshtt
+# trustymail is in PyPi, but often lags behind.
+git clone https://github.com/dhs-ncats/trustymail
 
 #########################################
 # If testing out a branch of domain-scan
@@ -21,6 +23,7 @@ git clone https://github.com/dhs-ncats/pshtt
 
 # cd pshtt
 # git checkout branch-name
+# cd ..
 
 #########################################
 # Repeatable from here.
@@ -29,6 +32,10 @@ git clone https://github.com/dhs-ncats/pshtt
 rm -r scan-env
 virtualenv-3.6 scan-env
 source scan-env/bin/activate
+
+cd trustymail
+pip install .
+cd ..
 
 cd pshtt
 pip install .
@@ -54,7 +61,8 @@ VENV=scan-env
 
 # Copy in a snapshot of the public suffix list in .txt form.
 # Need to find a more managed way to store this.
-cp /home/ec2-user/public-suffix-list.txt .
+wget -O ./public-suffix-list.txt \
+     https://publicsuffix.org/list/public_suffix_list.dat
 
 # Copy all packages, including any hidden dotfiles.
 cp -rT /home/ec2-user/$VENV/lib/python3.6/site-packages/ .

--- a/scanners/trustymail.py
+++ b/scanners/trustymail.py
@@ -1,7 +1,5 @@
 import logging
-from scanners import utils
 import os
-import json
 
 from trustymail import trustymail
 
@@ -64,7 +62,7 @@ def scan(domain, environment, options):
     }
 
     data = trustymail.scan(domain, timeout, smtp_timeout, smtp_localhost, smtp_ports, smtp_cache, scan_types, dns_hostnames).generate_results()
-    
+
     if not data:
         logging.warn("\ttrustymail command failed, skipping.")
 

--- a/scanners/trustymail.py
+++ b/scanners/trustymail.py
@@ -12,6 +12,9 @@ command = os.environ.get("TRUSTYMAIL_PATH", "trustymail")
 # default to a long timeout
 timeout = 30
 
+# Advertise lambda support
+lambda_support = True
+
 
 def scan(domain, environment, options):
 

--- a/scanners/trustymail.py
+++ b/scanners/trustymail.py
@@ -3,6 +3,8 @@ from scanners import utils
 import os
 import json
 
+from trustymail import trustymail
+
 ###
 # Inspect a site's DNS Mail configuration using DHS NCATS' trustymail tool.
 
@@ -17,29 +19,13 @@ lambda_support = True
 
 
 def scan(domain, environment, options):
+    # if options.get("debug", False):
+    #     full_command.append("--debug")
 
-    full_command = [
-        command,
-        domain,
-        '--json',
-        '--timeout', str(timeout),
-        # Use Google DNS
-        '--dns', '8.8.8.8,8.8.4.4'
-    ]
-
-    if options.get("debug", False):
-        full_command.append("--debug")
-
-    raw = utils.scan(full_command)
-
-    if not raw:
+    data = trustymail.scan(domain, timeout, 5, None, {25, 465, 587}, True, {'mx': True, 'starttls': True, 'spf': True, 'dmarc': True}, ['8.8.8.8', '8.8.4.4']).generate_results()
+    
+    if not data:
         logging.warn("\ttrustymail command failed, skipping.")
-        return None
-
-    data = json.loads(raw)
-
-    # trustymail uses JSON arrays, even for single items.
-    data = data[0]
 
     return data
 

--- a/scanners/trustymail.py
+++ b/scanners/trustymail.py
@@ -12,20 +12,64 @@ from trustymail import trustymail
 command = os.environ.get("TRUSTYMAIL_PATH", "trustymail")
 
 # default to a long timeout
-timeout = 30
+default_timeout = 30
+
+# This is the same default timeout used in trustymail/cli.py
+default_smtp_timeout = 5
+
+# These are the same default ports used in trustymail.cli.py
+default_smtp_ports = '25,465,587'
+
+# We want to enforce the use of Google DNS by default.  This gives
+# more consistent results.
+default_dns = '8.8.8.8,8.8.4.4'
 
 # Advertise lambda support
 lambda_support = True
 
 
 def scan(domain, environment, options):
-    # if options.get("debug", False):
-    #     full_command.append("--debug")
+    # Save the old logging level
+    old_log_level = logging.getLogger().getEffectiveLevel()
+    log_level = logging.WARN
+    if options.get('debug', False):
+        log_level = logging.DEBUG
+    logging.basicConfig(format='%(asctime)-15s %(message)s', level=log_level)
 
-    data = trustymail.scan(domain, timeout, 5, None, {25, 465, 587}, True, {'mx': True, 'starttls': True, 'spf': True, 'dmarc': True}, ['8.8.8.8', '8.8.4.4']).generate_results()
+    timeout = int(options.get('timeout', default_timeout))
+
+    smtp_timeout = int(options.get('smtp-timeout', default_smtp_timeout))
+
+    smtp_localhost = options.get('smtp-localhost', None)
+
+    smtp_ports = {int(port) for port in options.get('smtp-ports', default_smtp_ports).split(',')}
+
+    dns_hostnames = options.get('dns', default_dns).split(',')
+
+    # --starttls implies --mx
+    if options.get('starttls', False):
+        options.set('mx', True)
+
+    # Whether or not to use an in-memory SMTP cache.  For runs against
+    # a single domain this will not make any difference, unless an MX
+    # record is duplicated.
+    smtp_cache = not options.get('no-smtp-cache', False)
+
+    # User might not want every scan performed.
+    scan_types = {
+        'mx': options.get('mx', False),
+        'starttls': options.get('starttls', False),
+        'spf': options.get('spf', False),
+        'dmarc': options.get('dmarc', False)
+    }
+
+    data = trustymail.scan(domain, timeout, smtp_timeout, smtp_localhost, smtp_ports, smtp_cache, scan_types, dns_hostnames).generate_results()
     
     if not data:
         logging.warn("\ttrustymail command failed, skipping.")
+
+    # Reset the logging level
+    logging.getLogger().setLevel(old_log_level)
 
     return data
 


### PR DESCRIPTION
**Please merge #182 before this pull request, since this pull request includes the change in that one.**

Note that a side-effect of this pull request is that `domain-scan` now uses the `trustymail` API instead of calling the `trustymail` executable.  That's a plus.

I also made some minor improvements to the `lambda/remote_build.sh` script.
