### PR TITLE
Using BigQuery to get results from Censys.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,32 +188,38 @@ General options:
 * `--ignore-www`: Ignore the `www.` prefixes of hostnames. If `www.staging.example.com` is found, it will be treated as `staging.example.com`.
 * `--debug`: display extra output
 
-### `censys`: the Censys.io API
+### `censys`: Data from Censys.io via Google BigQuery
 
-To configure, set two environment variables from [your Censys account page](https://censys.io/account):
+Gathers hostnames from Censys.io via the Google BigQuery API.
 
-* `CENSYS_UID`: Your Censys API ID.
-* `CENSYS_API_KEY`: Your Censys secret.
+Before using this, you need to:
+
+* Create a Project in Google Cloud, and an associated service account with access to create new jobs/queries and get their results.
+* Give Censys.io this Google Cloud service account to grant access to.
+
+For details on concepts, and how to test access in the web console:
+
+* https://support.censys.io/google-bigquery/bigquery-introduction
+* https://support.censys.io/google-bigquery/adding-censys-datasets-to-bigquery
+
+Note that the web console access is based on access given to a Google account, but BigQuery API access via this script depends on access given to Google Cloud **service account** credentials.
+
+To configure access, set **one** of two environment variables:
+
+* `BIGQUERY_CREDENTIALS`: JSON data that contains your Google BigQuery service account credentials.
+* `BIGQUERY_CREDENTIALS_PATH`: A path to a file with JSON data that contains your Google BigQuery service account credentials.
 
 Options:
 
-* `--start`: Page number to start on (defaults to `1`)
-* `--end`: Page number to end on (defaults to value of `--start`)
-* `--delay`: Sleep between pages, to meet API limits. Defaults to 5s. If you have researcher access, shorten to 2s.
-* `--query`: Specify the Censys.io search query to use (overwrites the default one based on `--suffix`)
-
-To use the SQL export (which "researcher" accounts can do):
-
-* `--export`: Turn on export mode.
-* `--timeout`: Override timeout for waiting on job completion (in seconds).
-* `--force`: Ignore cached export data.
+* --timeout: Override the 10 minute job timeout (specify in seconds).
+* --cache: Use locally cached export data instead of hitting BigQuery.
 
 **Example:**
 
-Find `.gov` certificates in the first 2 pages of Censys API results, waiting 5 seconds between pages:
+Find hostnames ending in either `.gov` or `.fed.us` from within Censys.io's certificate database
 
 ```bash
-./gather censys --suffix=.gov --start=1 --end=2 --delay=5
+./gather censys --suffix=.gov,.fed.us
 ```
 
 ### Gathering Usage Examples

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ Or gather hostnames from multiple sources separated by commas:
 
 Right now there's one specific source (Censys.io), and then a general way of sourcing URLs or files by whatever name is convenient.
 
-**Censys.io** - The `censys` gatherer uses the [Censys.io API](https://censys.io/api), which has hostnames gathered from observed certificates. Censys provides certificates observed from a nightly zmap scan of the IPv4 space, as well as certificates published to public Certificate Transparency logs. Use `--export` to use the [Censys.io Export API](https://censys.io/api/v1/docs/export), which is faster and more complete but requires researcher credentials.
+**Censys.io** - The `censys` gatherer uses data from [Censys.io](https://censys.io), which has hostnames gathered from observed certificates, through the Google BigQuery API. Censys provides certificates observed from a nightly zmap scan of the IPv4 space, as well as certificates published to public Certificate Transparency logs.
 
 **Remote or local CSV** - By using any other name besides `censys`, this will define a gatherer based on an HTTP/HTTPS URL or local path to a CSV. Its only option is a flag named after itself. For example, using a gatherer name of `dap` will mean that domain-scan expects `--dap` to point to the URL or local file.
 

--- a/gatherers/censys.py
+++ b/gatherers/censys.py
@@ -1,240 +1,95 @@
 import os
-import csv
 import time
 import datetime
 import json
 import logging
 from scanners import utils
-from censys import certificates, export
-import censys
 
-# censys
+from google.cloud import bigquery
+from google.oauth2 import service_account
+import google.api_core.exceptions
+
+# Options:
 #
-# Gathers hostnames from the Censys.io API.
+# --timeout: Override the 5m job completion timeout (specify in seconds).
+# --cache: Use locally cached export data instead of hitting BigQuery.
+
+# Gathers hostnames from Censys.io via the Google BigQuery API.
 #
-# --censys_id: Censys API UID.
-# --censys_key: Censys API key.
+# Before using this, you need to:
 #
-# To use the paginated search (which all accounts can do):
-# --delay: How long to wait between requests. Defaults to 5s.
-#          If you have researcher credentials, use 2s.
-# --start: What page of results to start on. Defaults to 1.
-# --end:   What page of results to end on. Defaults to last page.
-# --force: Ignore cached pages.
+# * give Censys.io a Google Cloud account to grant access to.
+# * create a Project in Google Cloud, and associated API credentials.
+# * connect this Google Cloud account to Censys.io's BigQuery datasets.
 #
-# To use the SQL export (which "researcher" accounts can do):
-# --export: Turn on export mode.
-# --timeout: Override timeout for waiting on job completion (in seconds).
-# --force: Ignore cached export data.
+# For details, see:
 #
-# Export mode is much more thorough and quick. It will execute a SQL
-# query against Censys' export API. This will create a "job" in Censys'
-# queue, which the script will then repeatedly check against until
-# the job is done (or 20 minutes as a timeout). When the job is done,
-# the resulting CSV file will be downloaded to disk and cached, and
-# then read from for hostnames.
-#
-# However, export mode does require Censys credentials for an account
-# that has been enabled as a "researcher". If you don't have that, but
-# just have a regular free account, use the paginated mode. However,
-# know that the paginated mode might top out at 250 pages, because
-# the paginated mode talks to an Elasticsearch database which is
-# configured to a maximum of 25,000 records (100 records per page).
-#
-# TODO: Right now this only handle one download file. In theory, the
-# export API can return an array of multiple download files.
+# * https://support.censys.io/google-bigquery/bigquery-introduction
+# * https://support.censys.io/google-bigquery/adding-censys-datasets-to-bigquery
 
 
 def gather(suffixes, options, extra={}):
-    # Register a (free) Censys.io account to get a UID and API key.
-    uid = options.get("censys_id", None)
-    api_key = options.get("censys_key", None)
 
-    if (uid is None) or (api_key is None):
-        uid = os.environ.get("CENSYS_UID", None)
-        api_key = os.environ.get("CENSYS_API_KEY", None)
+    # Returns a parsed, processed Google service credentials object.
+    credentials = load_credentials()
 
-    if (uid is None) or (api_key is None):
-        logging.warn("No Censys credentials set. API key required to use the Censys API.")
+    if credentials is None:
+        logging.warn("No BigQuery credentials provided.")
+        logging.warn("Set BIGQUERY_CREDENTIALS or BIGQUERY_CREDENTIALS_PATH environment variables.")
         exit(1)
 
-    if options.get("export", False):
-        gather_method = export_mode
-    else:
-        gather_method = paginated_mode
+    # When using this form of instantiation, the client won't pull
+    # the project_id out of the creds, has to be set explicitly.
+    client = bigquery.Client(
+        project=credentials.project_id,
+        credentials=credentials
+    )
 
-    # Iterator doesn't buy much efficiency, since we paginated already.
-    # Necessary evil to de-dupe before returning hostnames, though.
-    for hostname in gather_method(suffixes, options, uid, api_key):
-        yield hostname
-
-
-def paginated_mode(suffixes, options, uid, api_key):
-    certificate_api = certificates.CensysCertificates(uid, api_key)
-
-    def suffix_query(suffix):
-        return "parsed.subject.common_name:\"%s\" or parsed.extensions.subject_alt_name.dns_names:\"%s\"" % (suffix, suffix)
-
-    if 'query' in options and options['query']:
-        query = options['query']
-    else:
-        query = str.join(" or ", [suffix_query(suffix) for suffix in suffixes])
-
-    logging.debug("Censys query:\n%s\n" % query)
-
-    # time to sleep between requests (defaults to 5s)
-    delay = int(options.get("delay", 5))
-
-    # Censys page size, fixed
-    page_size = 100
-
-    # Start page defaults to 1.
-    start_page = int(options.get("start", 1))
-
-    # End page defaults to whatever the API says is the last one.
-    end_page = options.get("end", None)
-    if end_page is None:
-        end_page = get_end_page(query, certificate_api)
-        if end_page is None:
-            logging.warn("Error looking up number of pages.")
-            exit(1)
-    else:
-        end_page = int(end_page)
-
-    max_records = ((end_page - start_page) + 1) * page_size
-
-    fields = [
-        "parsed.subject.common_name",
-        "parsed.extensions.subject_alt_name.dns_names"
-    ]
-
-    current_page = start_page
-
-    logging.warn("Fetching up to %i records, starting at page %i." % (max_records, start_page))
-    last_cached = False
-    force = options.get("force", False)
-
-    while current_page <= end_page:
-        if (not last_cached) and (current_page > start_page):
-            logging.debug("(Waiting %is before fetching page %i.)" % (delay, current_page))
-            last_cached = False
-            time.sleep(delay)
-
-        logging.debug("Fetching page %i." % current_page)
-
-        cache_page = utils.cache_path(str(current_page), "censys")
-        if (force is False) and (os.path.exists(cache_page)):
-            logging.warn("\t[%i] Cached page." % current_page)
-            last_cached = True
-
-            certs_raw = open(cache_page).read()
-            certs = json.loads(certs_raw)
-            if (certs.__class__ is dict) and certs.get('invalid'):
-                continue
-        else:
-            try:
-                certs = list(certificate_api.search(query, fields=fields, page=current_page, max_records=page_size))
-                utils.write(utils.json_for(certs), cache_page)
-            except censys.base.CensysException:
-                logging.warn(utils.format_last_exception())
-                logging.warn("Censys error, skipping page %i." % current_page)
-                utils.write(utils.invalid({}), cache_page)
-                continue
-            except:
-                logging.warn(utils.format_last_exception())
-                logging.warn("Unexpected error, skipping page %i." % current_page)
-                utils.write(utils.invalid({}), cache_page)
-                exit(1)
-
-        for cert in certs:
-            # Common name + SANs
-            names = cert.get('parsed.subject.common_name', []) + cert.get('parsed.extensions.subject_alt_name.dns_names', [])
-            # logging.debug(names)
-
-            for name in names:
-                yield name
-
-        current_page += 1
-
-    logging.debug("Done fetching from API.")
-
-
-def export_mode(suffixes, options, uid, api_key):
-
-    # Default timeout to 20 minutes.
-    default_timeout = 60 * 60 * 20
+    # Default timeout to 5 minutes.
+    default_timeout = 60 * 60 * 5
     timeout = int(options.get("timeout", default_timeout))
 
-    # Wait 5 seconds between checking on the job.
-    between_jobs = 5
-
-    try:
-        export_api = export.CensysExport(uid, api_key)
-    except censys.base.CensysUnauthorizedException:
-        logging.warn("The Censys.io Export API rejected the provided Censys credentials. The credentials may be inaccurate, or you may need to request access from the Censys.io team.")
-        exit(1)
-
-    def suffix_query(suffix):
-        return "parsed.subject.common_name LIKE \"%%%s\" OR parsed.extensions.subject_alt_name.dns_names LIKE \"%%%s\"" % (suffix, suffix)
-
-    # Uses a FLATTEN command in order to work around a BigQuery
-    # error around multiple "repeated" fields. *shrug*
-    body = str.join(" OR ", [suffix_query(suffix) for suffix in suffixes])
-    query = "SELECT parsed.subject.common_name, parsed.extensions.subject_alt_name.dns_names from FLATTEN([certificates.certificates], parsed.extensions.subject_alt_name.dns_names) where %s;" % (body)
+    # Construct the query.
+    query = query_for(suffixes)
     logging.debug("Censys query:\n%s\n" % query)
 
+    # Plan to store in cache/censys/export.csv.
     download_file = utils.cache_path("export", "censys", ext="csv")
 
-    force = options.get("force", False)
 
-    if (force is False) and os.path.exists(download_file):
+    # Reuse of cached data can be turned on with --cache.
+    cache = options.get("cache", False)
+    if (cache is True) and os.path.exists(download_file):
         logging.warn("Using cached download data.")
+
+
+    # But by default, fetch new data from the BigQuery API.
     else:
         logging.warn("Kicking off SQL query job.")
-        results_url = None
 
+        rows = None
+
+        # Actually execute the query.
         try:
-            job = export_api.new_job(query, format='csv', flatten=True)
-            job_id = job['job_id']
-
-            started = datetime.datetime.now()
-            while True:
-                elapsed = (datetime.datetime.now() - started).seconds
-
-                status = export_api.check_job(job_id)
-                if status['status'] == 'error':
-                    logging.warn("Error from Censys: %s" % status['error'])
-                    exit(1)
-
-                # Not expected, but better to explicitly handle.
-                elif status['status'] == 'expired':
-                    logging.warn("Results are somehow expired, bailing.")
-                    exit(1)
-
-                elif status['status'] == 'pending':
-                    logging.debug("[%is] Job still pending." % elapsed)
-                    time.sleep(between_jobs)
-
-                elif status['status'] == 'success':
-                    logging.warn("[%is] Job complete!" % elapsed)
-                    results_url = status['download_paths'][0]
-                    break
-
-                if (elapsed > timeout):
-                    logging.warn("Timeout waiting for job to complete.")
-                    exit(1)
-
-        except censys.base.CensysException:
+            # Executes query and loads all results into memory.
+            query_job = client.query(query)
+            iterator = query_job.result(timeout=timeout)
+            rows = list(iterator)
+        except google.api_core.exceptions.Forbidden:
+            logging.warn("Access denied to Censys' BigQuery tables.")
+        except:
             logging.warn(utils.format_last_exception())
-            logging.warn("Censys error, aborting.")
+            logging.warn("Error talking to BigQuery, aborting.")
+
+        print(rows[0])
+        exit(1)
 
         # At this point, the job is complete and we need to download
         # the resulting CSV URL in results_url.
-        logging.warn("Downloading results of SQL query.")
-        utils.download(results_url, download_file)
+        logging.warn("Caching results of SQL query.")
+        # TODO: cache in a CSV somewhere
 
-    # Read in downloaded CSV file, run any hostnames in each line
-    # through the sanitizer, and de-dupe using the map.
+    # Read in cached CSV file and yield one at a time.
     with open(download_file, newline='') as csvfile:
         for row in csv.reader(csvfile):
             if (not row[0]) or (row[0].lower().startswith("parsed_subject_common_name")):
@@ -248,9 +103,64 @@ def export_mode(suffixes, options, uid, api_key):
                     yield name
 
 
-# Hit the API once just to get the last available page number.
-def get_end_page(query, certificate_api):
-    metadata = certificate_api.metadata(query)
-    if metadata is None:
+# Constructs the query to run in BigQuery, against Censys'
+# certificate datasets, for one or more suffixes.
+#
+# Example query:
+#
+# SELECT
+#   parsed.subject.common_name,
+#   parsed.extensions.subject_alt_name.dns_names
+# FROM
+#   `censys-io.certificates_public.certificates`,
+#   UNNEST(parsed.subject.common_name) AS common_names,
+#   UNNEST(parsed.extensions.subject_alt_name.dns_names) AS sans
+# WHERE
+#   (common_names LIKE "%.gov"
+#     OR sans LIKE "%.gov")
+#   OR (common_names LIKE "%.fed.us"
+#     OR sans LIKE "%.fed.us");
+
+def query_for(suffixes):
+
+    select = """
+    parsed.subject.common_name,
+    parsed.extensions.subject_alt_name.dns_names
+    """
+
+    from_clause = """
+    `censys-io.certificates_public.certificates`,
+    UNNEST(parsed.subject.common_name) AS common_names,
+    UNNEST(parsed.extensions.subject_alt_name.dns_names) AS sans
+    """
+
+    # Returns query fragment for a specific suffix.
+    def suffix_query(suffix):
+        return """
+        (common_names LIKE \"%%%s\" OR sans LIKE \"%%%s\")
+        """ % (suffix, suffix)
+
+    # Join the individual suffix clauses into one WHERE clause.
+    where = str.join(" OR ", [suffix_query(suffix) for suffix in suffixes])
+
+    query = "SELECT %s FROM %s WHERE %s" % (select, from_clause, where)
+
+    return query
+
+
+# Load BigQuery credentials from either a JSON string, or
+# a JSON file. Passed in via environment variables either way.
+def load_credentials():
+    creds = os.environ.get("BIGQUERY_CREDENTIALS", None)
+
+    if creds is None:
+        path = os.environ.get("BIGQUERY_CREDENTIALS_PATH", None)
+        if path is not None:
+            with open(path) as f:
+                creds = f.read()
+
+    if creds is None:
         return None
-    return metadata.get('pages')
+
+    parsed = json.loads(creds)
+    return service_account.Credentials.from_service_account_info(parsed)

--- a/gatherers/censys.py
+++ b/gatherers/censys.py
@@ -1,6 +1,4 @@
 import os
-import time
-import datetime
 import json
 import csv
 import logging
@@ -63,12 +61,10 @@ def gather(suffixes, options, extra={}):
     # Plan to store in cache/censys/export.csv.
     download_path = utils.cache_path("export", "censys", ext="csv")
 
-
     # Reuse of cached data can be turned on with --cache.
     cache = options.get("cache", False)
     if (cache is True) and os.path.exists(download_path):
         logging.warn("Using cached download data.")
-
 
     # But by default, fetch new data from the BigQuery API,
     # and write it to the expected download location.

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,8 @@ sslyze
 cryptography
 
 # To support censys gatherer:
-censys
+google-cloud-bigquery
+google-auth-oauthlib
 
 # For Lambda support (only used locally):
 boto3


### PR DESCRIPTION
This removes all the code related to the Censys.io REST API (which we never use and which I can't really recommend for anything significant, since there's an upper limit on how many results can ever be fetched that way), and all code related to the Censys.io Export API (which is now defunct).

The `censys` gatherer in this PR talks to the Google BigQuery API, and exports hostnames using interactive queries to the `censys-io.certifcates` BigQuery table.

To download data this way, one needs to have been granted access by the Censys.io team, either as an academic researcher account, government researcher account, or as part of a commercial relationship. 

As of right now, this also requires some advance work -- creating a project in Google Cloud Platform, then creating a "service account" with access to create jobs and download data from one's own resources, and then giving that service account identifier to the Censys team for them to grant access to.

Once that's done, the service account JSON data can be set via environment variable, either:

* directly as a string via `BIGQUERY_CREDENTIALS` (e.g. in a PaaS environment), or 
* as a path to a file containing this JSON via `BIGQUERY_CREDENTIALS_PATH` (e.g. in a IaaS environment).

I've also switched this gatherer to make new API requests by default, rather than rely on locally cached data by default, so the `--force` flag has been replaced with a `--cache` flag. This is in line with the changes I made to the `./scan` pipeline in general in #155.

A `--timeout` option can adjust the query timeout from 10 minutes to some other value (in seconds).

Some Censys support pages relevant to this work:

* https://support.censys.io/google-bigquery/bigquery-introduction
* https://support.censys.io/google-bigquery/adding-censys-datasets-to-bigquery
* https://support.censys.io/google-bigquery/certificates-bigquery-dataset