### PR TITLE
Use with when opening PSL

### DIFF
--- a/scanners/utils.py
+++ b/scanners/utils.py
@@ -280,9 +280,9 @@ def load_suffix_list():
 
     if os.path.exists(cached_psl):
         logging.debug("Using cached Public Suffix List...")
-        psl_file = codecs.open(cached_psl, encoding='utf-8')
-        suffixes = publicsuffix.PublicSuffixList(psl_file)
-        content = psl_file.readlines()
+        with codecs.open(cached_psl, encoding='utf-8') as psl_file:
+            suffixes = publicsuffix.PublicSuffixList(psl_file)
+            content = psl_file.readlines()
     else:
         # File does not exist, download current list and cache it at given location.
         logging.debug("Downloading the Public Suffix List...")


### PR DESCRIPTION
A very minor improvement.  Use a `with` clause when opening the PSL so that the file gets closed immediately and does not have to wait to be garbage collected.