### PR TITLE
Fix for the fact that Python datetimes are formatted differently depending on whether Lambda is used

### DIFF
--- a/lambda/lambda_handler.py
+++ b/lambda/lambda_handler.py
@@ -46,7 +46,7 @@ def handler(event, context):
     }
 
     # Serialize and re-parse the JSON, so that we run our own
-    # date transform functions in one place, using the same function
-    # that runs locally.
+    # date transform functions in one place, before Amazon's built-in
+    # JSON serialization prepares the data for transport.
     return utils.from_json(utils.json_for(response))
 

--- a/scan
+++ b/scan
@@ -373,7 +373,15 @@ def perform_scan(params):
 # Let all errors bubble up to perform_scan.
 def perform_local_scan(scanner, domain, handles, environment, options, meta):
     logging.warn("\tExecuting local scan...")
-    return scanner.scan(domain, environment, options)
+    response = scanner.scan(domain, environment, options)
+
+    # Serialize and re-parse data as JSON, to normalize dates
+    # using explicit formatting regardless of local Python environment.
+    #
+    # This is also done for Lambda scans, but performed server-side
+    # by the Lambda handler so that it's done before Amazon's own
+    # JSON serialization is used for data transport to the client.
+    return utils.from_json(utils.json_for(response))
 
 
 ###

--- a/scanners/utils.py
+++ b/scanners/utils.py
@@ -104,7 +104,7 @@ def from_json(string):
 
 def format_datetime(obj):
     if isinstance(obj, datetime.date):
-        return obj.isoformat()
+        return obj.isoformat(' ')
     elif isinstance(obj, str):
         return obj
     else:

--- a/scanners/utils.py
+++ b/scanners/utils.py
@@ -104,7 +104,7 @@ def from_json(string):
 
 def format_datetime(obj):
     if isinstance(obj, datetime.date):
-        return obj.isoformat(' ')
+        return obj.isoformat()
     elif isinstance(obj, str):
         return obj
     else:


### PR DESCRIPTION
`isoformat()` should use a space as the separator instead of the default `T` character in order to agree with `__str__()`

This resolves #185.
  