### PR TITLE
Add check for Content-Security-Policy header

### DIFF
--- a/scanners/csp.py
+++ b/scanners/csp.py
@@ -1,0 +1,71 @@
+import logging
+import requests
+from scanners import utils
+
+###
+# CSP Scanner - check the presence of CSP headers
+#
+
+
+# Set a default number of workers for a particular scan type.
+# Overridden by a --workers flag.
+workers = 2
+
+
+# default to a custom user agent, can be overridden
+user_agent = "github.com/18f/domain-scan, csp.py"
+
+
+def init_domain(domain, environment, options):
+    # If we have data from pshtt, skip if it's not a live domain.
+    if utils.domain_not_live(domain):
+        logging.debug("\tSkipping, domain not reachable during inspection.")
+        return False
+
+    # If we have data from pshtt, skip if it's just a redirector.
+    if utils.domain_is_redirect(domain):
+        logging.debug("\tSkipping, domain seen as just an external redirector during inspection.")
+        return False
+
+    # requests needs a URL, not just a domain.
+    url = None
+    if not (domain.startswith('http://') or domain.startswith('https://')):
+
+        # If we have data from pshtt, use the canonical endpoint.
+        if utils.domain_canonical(domain):
+            url = utils.domain_canonical(domain)
+
+        # Otherwise, well, ssl should work.
+        else:
+            url = 'https://' + domain
+    else:
+        url = domain
+
+    return {'url': url}
+
+
+def scan(domain, environment, options):
+    logging.debug("CSP Check called with options: %s" % options)
+    url = environment.get("url", domain)
+    logging.debug("URL: %s", url)
+    response = requests.get(url)
+    csp_set = False
+    if "content-security-policy" in response.headers:
+        csp_set = True
+    logging.warn("Complete!")
+    return {
+        'csp_set': csp_set
+    }
+
+
+# Required CSV row conversion function. Usually one row, can be more.
+#
+# Run locally.
+def to_rows(data):
+    return [
+        [data['csp_set']]
+    ]
+
+
+# CSV headers for each row of data. Referenced locally.
+headers = ["CSP Set for domain"]


### PR DESCRIPTION
__What is the context of the pull request?__

As a response to the [BrowseAloud hack](http://www.bbc.co.uk/news/technology-43025788) which loaded a JS cryptocurrency mining malware, this commit adds a new scanner to check for the existance of the Content-Security-Policy header which seeks to limit the ability of dangerous content from execution.

This is an initial version that merely checks for the canonical header as currently implemented by common browsers. Future work should look out for common gotchas in wild card settings, etc. Comments / improvements welcome!

__How to test__

1. Check out the branch
2. Run a scan against Mozilla: `./scan mozilla.org --scan=csp`
3. Check that the output csv contains a True flag for mozilla.org `less ./results/csp.csv `
4. Run a fresh scan against gov.uk `./scan gov.uk --scan=csp`
5. Check that the output csv contains a False flag for gov.uk `less ./results/csp.csv ` (correct at PR checktime)

