### PR TITLE
Base domain's preload status not being passed to pshtt

### DIFF
--- a/scanners/pshtt.py
+++ b/scanners/pshtt.py
@@ -49,7 +49,7 @@ def init(environment, options):
 # per-scan.
 def init_domain(domain, environment, options):
     base_domain = utils.base_domain_for(domain)
-    
+
     preload_list = []
     if domain in environment.get("preload_list", []):
         preload_list.append(domain)


### PR DESCRIPTION
The base domain's preload status should be passed along as well, since this will impact the `pshtt` results.

With the old code, and running via AWS Lambda, one would see that the `pshtt` result for `fws.gov` would indicate the domain was preloaded while the `pshtt` result for `acebasin.fws.gov` would indicate that its base domain was not preloaded.  These two results are obviously contradictory.