### PR TITLE
Fix sorting algorithm to put header row on top consistently

### DIFF
--- a/utils/utils.py
+++ b/utils/utils.py
@@ -447,7 +447,7 @@ def sort_csv(input_filename):
 
     for row in csv.reader(input_file):
         # keep the header around
-        if (row[0].lower().startswith("domain")):
+        if (row[0].lower() == "domain"):
             header = row
             continue
 


### PR DESCRIPTION
The sort process was too lax on looking for `Domains` as a header row, causing e.g. `domains.dotgov.gov` to be sorted to the top as the header row when `--sort` was enabled during gathering. 

Since we're only sorting CSVs that we generate (as opposed to taking in input CSVs from a variety of possible sources), we can be more strict.