### PR TITLE
Add a hotfix for a problem encountering gzipped analytics files

### DIFF
--- a/scanners/analytics.py
+++ b/scanners/analytics.py
@@ -23,6 +23,7 @@ def init(environment, options):
         try:
             utils.download(analytics_file, analytics_path)
         except:
+            logging.error(utils.format_last_exception())
             no_csv = "--analytics URL not downloaded successfully."
             logging.error(no_csv)
             return False

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -3,6 +3,7 @@ import re
 import errno
 import subprocess
 import sys
+import gzip
 import shutil
 import traceback
 import json
@@ -34,9 +35,6 @@ def run(run_method, additional=None):
 
 
 # TODO: Somewhat better error handling.
-import gzip
-import shutil
-
 def download(url, destination):
     # make sure path is present
     mkdir_p(os.path.dirname(destination))
@@ -50,10 +48,9 @@ def download(url, destination):
 
         with gzip.GzipFile(filename, 'rb') as inf:
             with open(unzipped_file, 'w') as outf:
-                 outf.write(inf.read().decode('utf-8'))
+                outf.write(inf.read().decode('utf-8'))
 
         shutil.copyfile(unzipped_file, filename)
-
 
     return filename
 

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -34,11 +34,27 @@ def run(run_method, additional=None):
 
 
 # TODO: Somewhat better error handling.
+import gzip
+import shutil
+
 def download(url, destination):
     # make sure path is present
     mkdir_p(os.path.dirname(destination))
 
     filename, headers = urllib.request.urlretrieve(url, destination)
+
+    # If it's a gzipped file, ungzip it and replace it
+    if headers.get("Content-Encoding") == "gzip":
+        print("hey")
+        unzipped_file = filename + ".unzipped"
+
+        with gzip.GzipFile(filename, 'rb') as inf:
+            with open(unzipped_file, 'w') as outf:
+                 outf.write(inf.read().decode('utf-8'))
+
+        shutil.copyfile(unzipped_file, filename)
+
+
     return filename
 
 


### PR DESCRIPTION
The CSV at https://analytics.usa.gov/data/live/second-level-domains.csv started getting downloaded as binary gzip data instead of text. This caused the scanner to choke on a Unicode encoding error during parse time, which cascaded into a full failure of the `./scan` command (and was stopping scans on Pulse from running).

It'd be nice to handle this more gracefully in general, but this adds a hack-y way of gzipping any gzipped content downloaded in Python, and fixes the issue for now. This code path is currently only used by the `analytics` scanner.

cc @tdlowden 