### PR TITLE
Specifying PSL cache location in trustymail

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,7 @@
+.git
+.gitignore
+cache
 lambda
+public_suffix_list.dat
 results
 venv

--- a/Dockerfile
+++ b/Dockerfile
@@ -95,17 +95,22 @@ RUN echo 'eval "$(pyenv init -)"' >> /etc/profile \
 #     /opt/pyenv/sources/${PYENV_PYTHON_VERSION}-debug/Python-${PYENV_PYTHON_VERSION}/ \
 #     >> etc/gdb/gdbinit
 
+###
+# Update pip and setuptools to the latest versions
+###
+RUN pip install --upgrade pip setuptools
+
+###
+# domain-scan
+###
 COPY requirements.txt requirements.txt
-RUN pip install --upgrade pip \
-    && pip install --upgrade setuptools \
-    && pip install --upgrade -r requirements.txt
+RUN pip install --upgrade -r requirements.txt
 
 ###
 # Go
 ###
 ENV GOLANG_VERSION=1.8.3 PATH=/go/bin:/usr/src/go/bin:$PATH GOPATH=/go \
     GOROOT=/usr/src/go
-
 RUN curl -sSL https://storage.googleapis.com/golang/go${GOLANG_VERSION}.linux-amd64.tar.gz \
     | tar -v -C /usr/src -xz
 
@@ -125,7 +130,7 @@ RUN npm install --global phantomas phantomjs-prebuilt \
 ###
 RUN pip install --upgrade \
     git+https://github.com/dhs-ncats/pshtt.git@develop \
-    git+https://github.com/dhs-ncats/trustymail.git@develop
+    git+https://github.com/dhs-ncats/trustymail.git@bugfix/problem_with_psl_caching
 
 ###
 # Create unprivileged User
@@ -133,7 +138,7 @@ RUN pip install --upgrade \
 ENV SCANNER_HOME /home/scanner
 RUN mkdir $SCANNER_HOME \
     && groupadd -r scanner \
-    &&  useradd -r -c "Scanner user" -g scanner scanner \
+    && useradd -r -c "Scanner user" -g scanner scanner \
     && chown -R scanner:scanner ${SCANNER_HOME}
 
 ###

--- a/Dockerfile
+++ b/Dockerfile
@@ -130,7 +130,7 @@ RUN npm install --global phantomas phantomjs-prebuilt \
 ###
 RUN pip install --upgrade \
     git+https://github.com/dhs-ncats/pshtt.git@develop \
-    git+https://github.com/dhs-ncats/trustymail.git@bugfix/problem_with_psl_caching
+    git+https://github.com/dhs-ncats/trustymail.git@develop
 
 ###
 # Create unprivileged User

--- a/scanners/trustymail.py
+++ b/scanners/trustymail.py
@@ -1,21 +1,21 @@
 import logging
 import os
 
-from trustymail import trustymail
+import trustymail
+# Monkey patching trustymail to make it cache the PSL where we want
+trustymail.PublicSuffixListFilename = 'cache/public-suffix-list.txt'
+import trustymail.trustymail as tmail
 
 ###
 # Inspect a site's DNS Mail configuration using DHS NCATS' trustymail tool.
 
-# TODO: move to trustymail's Python API
-command = os.environ.get("TRUSTYMAIL_PATH", "trustymail")
-
 # default to a long timeout
 default_timeout = 30
 
-# This is the same default timeout used in trustymail/cli.py
+# This is the same default timeout used in trustymail/scripts/trustymail
 default_smtp_timeout = 5
 
-# These are the same default ports used in trustymail.cli.py
+# These are the same default ports used in trustymail/scripts/trustymail
 default_smtp_ports = '25,465,587'
 
 # We want to enforce the use of Google DNS by default.  This gives
@@ -61,10 +61,10 @@ def scan(domain, environment, options):
         'dmarc': options.get('dmarc', False)
     }
 
-    data = trustymail.scan(domain, timeout, smtp_timeout, smtp_localhost, smtp_ports, smtp_cache, scan_types, dns_hostnames).generate_results()
+    data = tmail.scan(domain, timeout, smtp_timeout, smtp_localhost, smtp_ports, smtp_cache, scan_types, dns_hostnames).generate_results()
 
     if not data:
-        logging.warn("\ttrustymail command failed, skipping.")
+        logging.warn("\ttrustymail scan failed, skipping.")
 
     # Reset the logging level
     logging.getLogger().setLevel(old_log_level)

--- a/scanners/trustymail.py
+++ b/scanners/trustymail.py
@@ -1,5 +1,4 @@
 import logging
-import os
 
 import trustymail
 # Monkey patching trustymail to make it cache the PSL where we want

--- a/scanners/trustymail.py
+++ b/scanners/trustymail.py
@@ -1,9 +1,9 @@
 import logging
 
+import trustymail.trustymail as tmail
 import trustymail
 # Monkey patching trustymail to make it cache the PSL where we want
 trustymail.PublicSuffixListFilename = 'cache/public-suffix-list.txt'
-import trustymail.trustymail as tmail
 
 ###
 # Inspect a site's DNS Mail configuration using DHS NCATS' trustymail tool.


### PR DESCRIPTION
Forcing `trustymail` to use the same PSL cache as the rest of `domain-scan` instead of its own.