### PR TITLE
Make flake8 ignore virtualenv directories.

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,4 +1,4 @@
 [flake8]
 ignore = E501,F999,E722
 max-line-length = 100
-exclude = .git,__pycache__,venv,cache,lambda
+exclude = .git,.venv,.venv-prod,__pycache__,venv,cache,lambda


### PR DESCRIPTION
I use pipenv locally, so excluding these would be helpful.