### PR TITLE
Use argparse for gather command parameters

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,4 +1,4 @@
 [flake8]
 ignore = E501,F999,E722
 max-line-length = 100
-exclude = .git,__pycache__,venv,cache,lambda
+exclude = .venv-prod,.git,__pycache__,venv,cache,lambda

--- a/.flake8
+++ b/.flake8
@@ -1,4 +1,4 @@
 [flake8]
 ignore = E501,F999,E722
 max-line-length = 100
-exclude = .venv-prod,.git,__pycache__,venv,cache,lambda
+exclude = .git,.venv,.venv-prod,.git,__pycache__,venv,cache,lambda

--- a/.flake8
+++ b/.flake8
@@ -1,4 +1,4 @@
 [flake8]
 ignore = E501,F999,E722
 max-line-length = 100
-exclude = .git,.venv,.venv-prod,.git,__pycache__,venv,cache,lambda
+exclude = .git,.venv,.venv-prod,__pycache__,venv,cache,lambda

--- a/gather
+++ b/gather
@@ -11,7 +11,7 @@ import importlib
 
 from utils import utils
 
-options = utils.options()
+options = utils.options_for_gather()
 utils.configure_logging(options)
 utils.mkdir_p(utils.cache_dir())
 utils.mkdir_p(utils.results_dir())
@@ -48,11 +48,11 @@ def run(options=None):
         os.remove(result)
 
     # Opt in to include parent (second-level) domains.
-    include_parents = options.get("include-parents", False)
+    include_parents = options.get("include_parents", False)
 
     # Opt into stripping www. prefixes from hostnames, effectively
     # collapsing www.[host] and [host] into one record.
-    ignore_www = options.get("ignore-www", False)
+    ignore_www = options.get("ignore_www", False)
 
     # --parents should be a CSV whose first column is parent domains
     # that will act as a whitelist for which subdomains to gather.

--- a/test.sh
+++ b/test.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env sh
 
 echo "running linters and tests..."
-flake8 . && python -m unittest discover tests
+# flake8 . && python -m unittest discover tests
+flake8 . && python -m pytest -vv tests

--- a/test.sh
+++ b/test.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env sh
 
 echo "running linters and tests..."
-flake8 . && python -m pytest tests
+flake8 . && python -m pytest -v tests

--- a/tests/context.py
+++ b/tests/context.py
@@ -1,0 +1,6 @@
+import os
+import sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+import utils  # noqa
+import gatherers  # noqa

--- a/tests/test_process_a11y.py
+++ b/tests/test_process_a11y.py
@@ -1,6 +1,6 @@
 import unittest
 
-from context import utils  # noqa
+from .context import utils  # noqa
 
 from utils.a11y.process_a11y import A11yProcessor
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,41 @@
+import sys
+import pytest
+from .context import utils  # noqa
+from utils import utils as subutils
+
+
+@pytest.mark.parametrize("args,expected", [
+    ("gather dap", {"_": ["dap"]}),
+    (
+        "".join([
+            "gather dap --suffix=.gov --dap=",
+            "https://analytics.usa.gov/data/live/sites-extended.csv"]),
+        {
+            "_": ["dap"],
+            "suffix": ".gov",
+            "dap": "https://analytics.usa.gov/data/live/sites-extended.csv",
+        }
+    ),
+    (
+        "".join([
+            "./gather censys,dap,private --suffix=.gov --dap=",
+            "https://analytics.usa.gov/data/live/sites-extended.csv",
+            " --private=/path/to/private-research.csv --parents="
+            "https://github.com/GSA/data/raw/master/dotgov-domains/current-federal.csv",
+            " --export"
+        ]),
+        {
+            '_': ['censys,dap,private'],
+            'suffix': '.gov',
+            'dap': 'https://analytics.usa.gov/data/live/sites-extended.csv',
+            'private': '/path/to/private-research.csv',
+            'parents': 'https://github.com/GSA/data/raw/master/dotgov-domains/current-federal.csv',
+            'export': True
+        }
+    ),
+])
+def test_options(monkeypatch, args, expected):
+    monkeypatch.setattr(sys, "argv", args.split(" "))
+    result = subutils.options()
+    pytest.set_trace()
+    assert result == expected

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -5,14 +5,49 @@ from .context import utils  # noqa
 from utils import utils as subutils
 
 
+def get_gather_default_false_values():
+    # Get these from the parser rather than having to keep a manual list.
+    parser = subutils.build_gather_options_parser([])
+    optional_actions = parser._get_optional_actions()
+    default_false_values = {}
+    for oa in optional_actions:
+        if oa.nargs == 0 and oa.const is True and oa.default is False:
+            default_false_values.update(**{oa.dest: False})
+    return default_false_values
+
+
+def get_gather_args_with_mandatory_values():
+    # Get these from the parser rather than having to keep a manual list.
+    parser = subutils.build_gather_options_parser([])
+    optional_actions = parser._get_optional_actions()
+    mandatory_value_args = []
+    for oa in optional_actions:
+        if oa.nargs in ("?", "+"):
+            mandatory_value_args.append(oa.dest)
+    return mandatory_value_args
+
+
+gather_default_false_values = get_gather_default_false_values()
+gather_args_with_mandatory_values = get_gather_args_with_mandatory_values()
+
+
 @pytest.mark.parametrize("args,expected", [
-    ("gather dap", {"_": ["dap"]}),
+    (
+        "gather dap --dap=someurl --suffix=.gov",
+        {
+            "_": ["dap"],
+            "dap": "someurl",
+            "suffix": ".gov",
+            **gather_default_false_values,
+        }
+    ),
     (
         "".join([
             "gather dap --suffix=.gov --dap=",
             "https://analytics.usa.gov/data/live/sites-extended.csv"]),
         {
             "_": ["dap"],
+            **gather_default_false_values,
             "suffix": ".gov",
             "dap": "https://analytics.usa.gov/data/live/sites-extended.csv",
         }
@@ -26,6 +61,7 @@ from utils import utils as subutils
         ]),
         {
             '_': ['censys,dap,private'],
+            **gather_default_false_values,
             'suffix': '.gov',
             'dap': 'https://analytics.usa.gov/data/live/sites-extended.csv',
             'private': '/path/to/private-research.csv',
@@ -38,40 +74,95 @@ from utils import utils as subutils
             "https://analytics.usa.gov/data/live/sites-extended.csv",
             " --private=/path/to/private-research.csv --parents=",
             "https://github.com/GSA/data/raw/master/dotgov-domains/current-federal.csv",
-            " --a11y_config=something.json"
         ]),
         {
             '_': ['censys,dap,private'],
+            **gather_default_false_values,
             'suffix': '.gov',
             'dap': 'https://analytics.usa.gov/data/live/sites-extended.csv',
             'private': '/path/to/private-research.csv',
             'parents': 'https://github.com/GSA/data/raw/master/dotgov-domains/current-federal.csv',
-            'a11y_config': 'something.json'
+        }
+    ),
+    (
+        "".join([
+            "./gather dap --suffix=.gov --dap=",
+            "https://analytics.usa.gov/data/live/sites-extended.csv",
+            " --ignore-www",
+        ]),
+        {
+            '_': ['dap'],
+            **gather_default_false_values,
+            'suffix': '.gov',
+            'dap': 'https://analytics.usa.gov/data/live/sites-extended.csv',
+            'ignore_www': True,
+        }
+    ),
+    (
+        "".join([
+            "./gather dap --suffix=.gov --dap=",
+            "https://analytics.usa.gov/data/live/sites-extended.csv",
+            " --include-parents",
+        ]),
+        {
+            '_': ['dap'],
+            **gather_default_false_values,
+            'suffix': '.gov',
+            'dap': 'https://analytics.usa.gov/data/live/sites-extended.csv',
+            'include_parents': True,
+        }
+    ),
+    (
+        "".join([
+            "./gather dap --suffix=.gov --dap=",
+            "https://analytics.usa.gov/data/live/sites-extended.csv",
+            " --cache",
+        ]),
+        {
+            '_': ['dap'],
+            **gather_default_false_values,
+            'suffix': '.gov',
+            'dap': 'https://analytics.usa.gov/data/live/sites-extended.csv',
+            'cache': True,
+        }
+    ),
+    (
+        "".join([
+            "./gather dap --suffix=.gov --dap=",
+            "https://analytics.usa.gov/data/live/sites-extended.csv",
+            " --debug",
+        ]),
+        {
+            '_': ['dap'],
+            **gather_default_false_values,
+            'suffix': '.gov',
+            'dap': 'https://analytics.usa.gov/data/live/sites-extended.csv',
+            'debug': True,
         }
     ),
 ])
-def test_options(monkeypatch, args, expected):
+def test_options_for_gather(monkeypatch, args, expected):
     monkeypatch.setattr(sys, "argv", args.split(" "))
-    result = subutils.options()
+    result = subutils.options_for_gather()
     assert result == expected
 
 
 @pytest.mark.parametrize("args", [
-    "./gather a11y --suffix=.gov --a11y_config=shouldbejson.fail",
-    "./gather a11y --suffix=.gov --a11y_redirects=shouldbeyml.fail",
+    "./gather censys --suffix",
+    "./gather dap,censys --dap --suffix=.gov",
+    "./gather dap --dap --suffix=.gov",
+    "./gather dap --dap=something.url --suffix=.gov --parents",
 ])
 @pytest.mark.xfail(raises=argparse.ArgumentError)
-def test_options_bad_arg(monkeypatch, args):
+def test_options_for_gather_missing_arg_parameter(monkeypatch, args):
     monkeypatch.setattr(sys, "argv", args.split(" "))
-    subutils.options()
+    subutils.options_for_gather()
 
 
 @pytest.mark.parametrize("args", [
-    "./gather a11y --a11y_config",
-    "./gather a11y --a11y_redirects",
-    "./gather a11y --analytics",
+    "./gather censys --a11y_config=file.json --suffix=.gov",
 ])
-@pytest.mark.xfail(raises=argparse.ArgumentError)
-def test_options_missing_arg_parameter(monkeypatch, args):
+@pytest.mark.xfail(raises=argparse.ArgumentTypeError)
+def test_options_for_gather_arg_mismatch(monkeypatch, args):
     monkeypatch.setattr(sys, "argv", args.split(" "))
-    subutils.options()
+    subutils.options_for_gather()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -171,9 +171,9 @@ def test_options_for_gather_arg_mismatch(monkeypatch, args):
 @pytest.mark.parametrize("args", gather_args_with_mandatory_values)
 @pytest.mark.xfail(raises=argparse.ArgumentError)
 def test_options_for_gather_missing_mandatory(monkeypatch, args):
-    command = f"./gather censys --suffix=.gov --{args}"
+    command = "./gather censys --suffix=.gov --%s" % args
     monkeypatch.setattr(sys, "argv", command.split(" "))
     subutils.options_for_gather()
-    command = f"./gather censys --suffix=.gov --{args}="
+    command = "./gather censys --suffix=.gov --%s=" % args
     monkeypatch.setattr(sys, "argv", command.split(" "))
     subutils.options_for_gather()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -22,7 +22,7 @@ def get_gather_args_with_mandatory_values():
     optional_actions = parser._get_optional_actions()
     mandatory_value_args = []
     for oa in optional_actions:
-        if oa.nargs in ("?", "+"):
+        if oa.nargs in ("?", "+", 1):
             mandatory_value_args.append(oa.dest)
     return mandatory_value_args
 
@@ -165,4 +165,15 @@ def test_options_for_gather_missing_arg_parameter(monkeypatch, args):
 @pytest.mark.xfail(raises=argparse.ArgumentTypeError)
 def test_options_for_gather_arg_mismatch(monkeypatch, args):
     monkeypatch.setattr(sys, "argv", args.split(" "))
+    subutils.options_for_gather()
+
+
+@pytest.mark.parametrize("args", gather_args_with_mandatory_values)
+@pytest.mark.xfail(raises=argparse.ArgumentError)
+def test_options_for_gather_missing_mandatory(monkeypatch, args):
+    command = f"./gather censys --suffix=.gov --{args}"
+    monkeypatch.setattr(sys, "argv", command.split(" "))
+    subutils.options_for_gather()
+    command = f"./gather censys --suffix=.gov --{args}="
+    monkeypatch.setattr(sys, "argv", command.split(" "))
     subutils.options_for_gather()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,3 +1,4 @@
+import argparse
 import sys
 import pytest
 from .context import utils  # noqa
@@ -20,9 +21,8 @@ from utils import utils as subutils
         "".join([
             "./gather censys,dap,private --suffix=.gov --dap=",
             "https://analytics.usa.gov/data/live/sites-extended.csv",
-            " --private=/path/to/private-research.csv --parents="
+            " --private=/path/to/private-research.csv --parents=",
             "https://github.com/GSA/data/raw/master/dotgov-domains/current-federal.csv",
-            " --export"
         ]),
         {
             '_': ['censys,dap,private'],
@@ -30,12 +30,48 @@ from utils import utils as subutils
             'dap': 'https://analytics.usa.gov/data/live/sites-extended.csv',
             'private': '/path/to/private-research.csv',
             'parents': 'https://github.com/GSA/data/raw/master/dotgov-domains/current-federal.csv',
-            'export': True
+        }
+    ),
+    (
+        "".join([
+            "./gather censys,dap,private --suffix=.gov --dap=",
+            "https://analytics.usa.gov/data/live/sites-extended.csv",
+            " --private=/path/to/private-research.csv --parents=",
+            "https://github.com/GSA/data/raw/master/dotgov-domains/current-federal.csv",
+            " --a11y_config=something.json"
+        ]),
+        {
+            '_': ['censys,dap,private'],
+            'suffix': '.gov',
+            'dap': 'https://analytics.usa.gov/data/live/sites-extended.csv',
+            'private': '/path/to/private-research.csv',
+            'parents': 'https://github.com/GSA/data/raw/master/dotgov-domains/current-federal.csv',
+            'a11y_config': 'something.json'
         }
     ),
 ])
 def test_options(monkeypatch, args, expected):
     monkeypatch.setattr(sys, "argv", args.split(" "))
     result = subutils.options()
-    pytest.set_trace()
     assert result == expected
+
+
+@pytest.mark.parametrize("args", [
+    "./gather a11y --suffix=.gov --a11y_config=shouldbejson.fail",
+    "./gather a11y --suffix=.gov --a11y_redirects=shouldbeyml.fail",
+])
+@pytest.mark.xfail(raises=argparse.ArgumentError)
+def test_options_bad_arg(monkeypatch, args):
+    monkeypatch.setattr(sys, "argv", args.split(" "))
+    subutils.options()
+
+
+@pytest.mark.parametrize("args", [
+    "./gather a11y --a11y_config",
+    "./gather a11y --a11y_redirects",
+    "./gather a11y --analytics",
+])
+@pytest.mark.xfail(raises=argparse.ArgumentError)
+def test_options_missing_arg_parameter(monkeypatch, args):
+    monkeypatch.setattr(sys, "argv", args.split(" "))
+    subutils.options()

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -86,7 +86,7 @@ def options_endswith(end):
     def func(arg):
         if arg.endswith(end):
             return arg
-        raise argparse.ArgumentTypeError(f"value must end in '{end}'")
+        raise argparse.ArgumentTypeError("value must end in '%s'" % end)
     return func
 
 
@@ -130,7 +130,7 @@ def build_gather_options_parser(services):
     parser = ArgumentParser(prefix_chars="--")
 
     for service in services:
-        flag = f"--{service}"
+        flag = "--%s" % service
         parser.add_argument(flag, nargs=1, required=True)
 
     parser.add_argument("--cache", action="store_true")
@@ -155,7 +155,7 @@ def options_for_gather():
     for remainder in remaining:
         if remainder.startswith("--"):
             raise argparse.ArgumentTypeError(
-                f"{remainder} isn't a valid argument here.")
+                "%s isn't a valid argument here." % remainder)
     opts = parsed.__dict__
     opts = {k: opts[k] for k in opts if opts[k] is not None}
     opts["_"] = remaining

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -1,3 +1,4 @@
+import argparse
 import os
 import re
 import errno
@@ -58,7 +59,7 @@ def download(url, destination):
 # read options from the command line
 #   e.g. ./scan --since=2012-03-04 --debug whatever.com
 #     => {"since": "2012-03-04", "debug": True, "_": ["whatever.com"]}
-def options():
+def xoptions():
     options = {"_": []}
     for arg in sys.argv[1:]:
         if arg.startswith("--"):
@@ -77,6 +78,22 @@ def options():
         else:
             options["_"].append(arg)
     return options
+
+
+def options():
+    parser = argparse.ArgumentParser(prefix_chars="--")
+    parser.add_argument("--suffix", nargs="?")
+    parser.add_argument("--dap", nargs="?")
+    parser.add_argument("--private", nargs="?")
+    parser.add_argument("--parents", nargs="?")
+    parser.add_argument("--export", action="store_true")
+    parsed, remaining = parser.parse_known_args()
+    import pytest
+    pytest.set_trace()
+    opts = parsed.__dict__
+    opts = {k: opts[k] for k in opts if opts[k] is not None}
+    opts["_"] = remaining
+    return opts
 
 
 def configure_logging(options=None):


### PR DESCRIPTION
The Python standard
Library has many things.
Argparse isn't bad.

Switch the gather command over to using argparse for handling its arguments, and add tests.

My main fear here is that there's some obscure invocation I've broken in making this change, so please let me know if I've missed some corner cases.