### PR TITLE
Reverting to older sslyze

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -25,7 +25,7 @@ ipython
 git+git://github.com/dhs-ncats/pshtt.git#egg=pshtt
 
 # sslyze
-sslyze>=1.4.0
+sslyze>=1.3.4,<1.4.0
 cryptography
 
 # a11y

--- a/scanners/sslyze.py
+++ b/scanners/sslyze.py
@@ -14,7 +14,7 @@
 
 import logging
 
-from sslyze.server_connectivity_tester import ServerConnectivityTester, ServerConnectivityError
+import sslyze
 from sslyze.synchronous_scanner import SynchronousScanner
 from sslyze.concurrent_scanner import ConcurrentScanner, PluginRaisedExceptionScanResult
 from sslyze.plugins.openssl_cipher_suites_plugin import Tlsv10ScanCommand, Tlsv11ScanCommand, Tlsv12ScanCommand, Sslv20ScanCommand, Sslv30ScanCommand
@@ -379,10 +379,19 @@ def init_sslyze(hostname, port, starttls_smtp, options, sync=False):
         tls_wrapped_protocol = TlsWrappedProtocolEnum.STARTTLS_SMTP
 
     try:
+        server_info = sslyze.server_connectivity.ServerConnectivityInfo(hostname=hostname, port=port, tls_wrapped_protocol=tls_wrapped_protocol)
+    except sslyze.server_connectivity.ServerConnectivityError as error:
+        logging.warn("\tServer connectivity not established during initialization.")
+        return None, None
+    except Exception as err:
+        utils.notify(err)
+        logging.warn("\tUnknown exception when initializing server connectivity info.")
+        return None, None
+
+    try:
         # logging.debug("\tTesting connectivity with timeout of %is." % network_timeout)
-        server_tester = ServerConnectivityTester(hostname=hostname, port=port, tls_wrapped_protocol=tls_wrapped_protocol)
-        server_info = server_tester.perform(network_timeout=network_timeout)
-    except ServerConnectivityError as err:
+        server_info.test_connectivity_to_server(network_timeout=network_timeout)
+    except sslyze.server_connectivity.ServerConnectivityError as err:
         logging.warn("\tServer connectivity not established during test.")
         return None, None
     except Exception as err:


### PR DESCRIPTION
The new 1.4 version of sslyze seems to eventually segfault when I scan.  As a result I'm reverting to the latest 1.3 version.  

This issue is impacting the NCATS HTTPS and Trustworthy Email scanning.