### PR TITLE
Removing explicit dependency on pshtt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -21,9 +21,6 @@ ipython
 # Scanners
 ############
 
-# pshtt
-git+git://github.com/dhs-ncats/pshtt.git#egg=pshtt
-
 # sslyze
 sslyze>=1.3.4,<1.4.0
 cryptography

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,7 +25,7 @@ ipython
 git+git://github.com/dhs-ncats/pshtt.git#egg=pshtt
 
 # sslyze
-sslyze>=1.4.0
+sslyze>=1.3.4,<1.4.0
 cryptography
 
 # a11y

--- a/scanners/sslyze.py
+++ b/scanners/sslyze.py
@@ -14,7 +14,7 @@
 
 import logging
 
-from sslyze.server_connectivity_tester import ServerConnectivityTester, ServerConnectivityError
+import sslyze
 from sslyze.synchronous_scanner import SynchronousScanner
 from sslyze.concurrent_scanner import ConcurrentScanner, PluginRaisedExceptionScanResult
 from sslyze.plugins.openssl_cipher_suites_plugin import Tlsv10ScanCommand, Tlsv11ScanCommand, Tlsv12ScanCommand, Sslv20ScanCommand, Sslv30ScanCommand
@@ -379,10 +379,19 @@ def init_sslyze(hostname, port, starttls_smtp, options, sync=False):
         tls_wrapped_protocol = TlsWrappedProtocolEnum.STARTTLS_SMTP
 
     try:
+        server_info = sslyze.server_connectivity.ServerConnectivityInfo(hostname=hostname, port=port, tls_wrapped_protocol=tls_wrapped_protocol)
+    except sslyze.server_connectivity.ServerConnectivityError as error:
+        logging.warn("\tServer connectivity not established during initialization.")
+        return None, None
+    except Exception as err:
+        utils.notify(err)
+        logging.warn("\tUnknown exception when initializing server connectivity info.")
+        return None, None
+
+    try:
         # logging.debug("\tTesting connectivity with timeout of %is." % network_timeout)
-        server_tester = ServerConnectivityTester(hostname=hostname, port=port, tls_wrapped_protocol=tls_wrapped_protocol)
-        server_info = server_tester.perform(network_timeout=network_timeout)
-    except ServerConnectivityError as err:
+        server_info.test_connectivity_to_server(network_timeout=network_timeout)
+    except sslyze.server_connectivity.ServerConnectivityError as err:
         logging.warn("\tServer connectivity not established during test.")
         return None, None
     except Exception as err:


### PR DESCRIPTION
`trustymail` isn't included in this way, and it often breaks things when I'm testing and want to use a different version of `pshtt`.  It will also save some space for those creating Docker containers for scanning that do not require `pshtt`.