### PR TITLE
Removing the explicit pshtt dependency from requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -21,9 +21,6 @@ ipython
 # Scanners
 ############
 
-# pshtt
-git+git://github.com/dhs-ncats/pshtt.git#egg=pshtt
-
 # sslyze
 sslyze>=1.3.4,<1.4.0
 cryptography


### PR DESCRIPTION
`trustymail` isn't included in this way, and it often breaks things when I'm testing and want to use a different version of `pshtt`.  It will also save some space for those creating Docker containers for scanning that do not require `pshtt`.

I'm also open to removing the explicit `sslyze` dependency, for similar reasons.