### PR TITLE
Don't duplicate contents of requirements-lambda.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,5 @@
 # invocation.
 boto3
 
-# Used in Lambda functions. Also copied to lambda/requirements-lambda.txt.
-strict-rfc3339
-publicsuffix
+# Used in Lambda functions
+-r lambda/requirements-lambda.txt


### PR DESCRIPTION
Including `requirements-lambda.txt` inside `requirements.txt` instead of duplicating the contents