### PR TITLE
PSL now stored in same cache location in lambda and local

### DIFF
--- a/scanners/pshtt.py
+++ b/scanners/pshtt.py
@@ -21,7 +21,7 @@ suffix_list = None
 
 # In Lambda, we package a snapshot of the PSL with the environment.
 lambda_support = True
-lambda_suffix_path = "./public-suffix-list.txt"
+lambda_suffix_path = "./cache/public-suffix-list.txt"
 
 
 # Download third party data once, at the top of the scan.

--- a/scanners/trustymail.py
+++ b/scanners/trustymail.py
@@ -57,16 +57,10 @@ def scan(domain, environment, options):
     }
 
     import trustymail
-    if environment['scan_method'] == 'local':
-        # Local scanning
-        #
-        # Monkey patching trustymail to make it cache the PSL where we want
-        trustymail.PublicSuffixListFilename = 'cache/public-suffix-list.txt'
-    else:
-        # Lambda scanning
-        #
-        # Monkey patching trustymail to make it cache the PSL where we want
-        trustymail.PublicSuffixListFilename = './public-suffix-list.txt'
+    # Monkey patching trustymail to make it cache the PSL where we
+    # want
+    trustymail.PublicSuffixListFilename = 'cache/public-suffix-list.txt'
+    if environment['scan_method'] == 'lambda':
         # Monkey patching trustymail to make the PSL cache read-only
         trustymail.PublicSuffixListReadOnly = True
     import trustymail.trustymail as tmail


### PR DESCRIPTION
Now storing the PSL in the same cache location when running in Lambda and when running locally