### PR TITLE
Fix some issues with gather options parsing with hyphenated sources

### DIFF
--- a/scanners/analytics.py
+++ b/scanners/analytics.py
@@ -18,9 +18,10 @@ def init(environment, options):
     # It's a URL, download it first.
     if analytics_file.startswith("http:") or analytics_file.startswith("https:"):
 
-        analytics_path = os.path.join(utils.cache_dir(), "analytics.csv")
+        analytics_path = os.path.join(utils.cache_dir(options), "analytics.csv")
 
         try:
+            logging.debug("Downloading analytics file at %s ..." % analytics_file)
             utils.download(analytics_file, analytics_path)
         except:
             logging.error(utils.format_last_exception())

--- a/scanners/analytics.py
+++ b/scanners/analytics.py
@@ -18,7 +18,7 @@ def init(environment, options):
     # It's a URL, download it first.
     if analytics_file.startswith("http:") or analytics_file.startswith("https:"):
 
-        analytics_path = os.path.join(utils.cache_dir(options), "analytics.csv")
+        analytics_path = os.path.join(options["_"]["cache_dir"], "analytics.csv")
 
         try:
             logging.debug("Downloading analytics file at %s ..." % analytics_file)

--- a/scanners/sslyze.py
+++ b/scanners/sslyze.py
@@ -201,7 +201,7 @@ def run_sslyze(data, environment, options):
     if scan_method == "lambda":
         sync = True
     else:
-        sync = options.get("sslyze-serial", True)
+        sync = options.get("sslyze_serial", True)
 
     # Initialize either a synchronous or concurrent scanner.
     server_info, scanner = init_sslyze(data['hostname'], data['port'], data['starttls_smtp'], options, sync=sync)
@@ -477,7 +477,7 @@ def scan_serial(scanner, server_info, data, options):
     tlsv1_3 = scanner.run_scan_command(server_info, Tlsv13ScanCommand())
 
     certs = None
-    if options.get("sslyze-certs", True) is True:
+    if options.get("sslyze_certs", True) is True:
 
         try:
             logging.debug("\t\tCertificate information scan.")

--- a/scanners/trustymail.py
+++ b/scanners/trustymail.py
@@ -31,11 +31,11 @@ def scan(domain, environment, options):
 
     timeout = int(options.get('timeout', default_timeout))
 
-    smtp_timeout = int(options.get('smtp-timeout', default_smtp_timeout))
+    smtp_timeout = int(options.get('smtp_timeout', default_smtp_timeout))
 
-    smtp_localhost = options.get('smtp-localhost', None)
+    smtp_localhost = options.get('smtp_localhost', None)
 
-    smtp_ports = {int(port) for port in options.get('smtp-ports', default_smtp_ports).split(',')}
+    smtp_ports = {int(port) for port in options.get('smtp_ports', default_smtp_ports).split(',')}
 
     dns_hostnames = options.get('dns', default_dns).split(',')
 
@@ -46,7 +46,7 @@ def scan(domain, environment, options):
     # Whether or not to use an in-memory SMTP cache.  For runs against
     # a single domain this will not make any difference, unless an MX
     # record is duplicated.
-    smtp_cache = not options.get('no-smtp-cache', False)
+    smtp_cache = not options.get('no_smtp_cache', False)
 
     # User might not want every scan performed.
     scan_types = {

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -6,14 +6,16 @@ from utils import utils as subutils
 from utils import scan_utils
 
 
-def get_default_false_values(parser):
+def get_default_values(parser):
     # Get these from the parser rather than having to keep a manual list.
     optional_actions = parser._get_optional_actions()
-    default_false_values = {}
+    default_values = {}
     for oa in optional_actions:
-        if oa.nargs == 0 and oa.const is True and oa.default is False:
-            default_false_values.update(**{oa.dest: False})
-    return default_false_values
+        if oa.nargs == 0 and oa.const is True and oa.default is not None:
+            default_values.update(**{oa.dest: oa.default})
+        elif oa.nargs == 1 and oa.default is not None:
+            default_values.update(**{oa.dest: oa.default[0]})
+    return default_values
 
 
 def get_args_with_mandatory_values(parser):
@@ -26,11 +28,11 @@ def get_args_with_mandatory_values(parser):
     return mandatory_value_args
 
 
-gather_default_false_values = get_default_false_values(
+gather_default_values = get_default_values(
     subutils.build_gather_options_parser([]))
 gather_args_with_mandatory_values = get_args_with_mandatory_values(
     subutils.build_gather_options_parser([]))
-scan_default_false_values = get_default_false_values(
+scan_default_values = get_default_values(
     scan_utils.build_scan_options_parser())
 scan_args_with_mandatory_values = get_args_with_mandatory_values(
     scan_utils.build_scan_options_parser())
@@ -43,7 +45,7 @@ default_underscore_scan = {
     **default_underscore_both
 }
 default_underscore_gather = {
-    **default_underscore_both
+    **default_underscore_both,
 }
 
 
@@ -54,7 +56,8 @@ default_underscore_gather = {
             "gatherers": ["dap"],
             "dap": "someurl",
             "suffix": [".gov"],
-            **gather_default_false_values,
+            **gather_default_values,
+            "_": {**default_underscore_gather},
         }
     ),
     (
@@ -63,7 +66,8 @@ default_underscore_gather = {
             "gatherers": ["dap"],
             "dap": "someurl",
             "suffix": [".gov"],
-            **gather_default_false_values,
+            **gather_default_values,
+            "_": {**default_underscore_gather},
         }
     ),
     (
@@ -72,7 +76,8 @@ default_underscore_gather = {
             "gatherers": ["dap"],
             "dap": "someurl",
             "suffix": [".gov"],
-            **gather_default_false_values,
+            **gather_default_values,
+            "_": {**default_underscore_gather},
         }
     ),
     (
@@ -81,7 +86,8 @@ default_underscore_gather = {
             "gatherers": ["dap"],
             "dap": "someurl",
             "suffix": [".gov"],
-            **gather_default_false_values,
+            **gather_default_values,
+            "_": {**default_underscore_gather},
         }
     ),
     (
@@ -90,7 +96,8 @@ default_underscore_gather = {
             "gatherers": ["dap"],
             "dap": "someurl",
             "suffix": [".gov", ".gov.uk"],
-            **gather_default_false_values,
+            **gather_default_values,
+            "_": {**default_underscore_gather},
         }
     ),
     (
@@ -99,7 +106,8 @@ default_underscore_gather = {
             "gatherers": ["dap"],
             "dap": "someurl",
             "suffix": [".gov", ".gov.uk"],
-            **gather_default_false_values,
+            **gather_default_values,
+            "_": {**default_underscore_gather},
         }
     ),
     (
@@ -108,7 +116,8 @@ default_underscore_gather = {
             "gatherers": ["dap"],
             "dap": "someurl",
             "suffix": [".gov", ".gov.uk"],
-            **gather_default_false_values,
+            **gather_default_values,
+            "_": {**default_underscore_gather},
         }
     ),
     (
@@ -117,7 +126,8 @@ default_underscore_gather = {
             "https://analytics.usa.gov/data/live/sites-extended.csv"]),
         {
             "gatherers": ["dap"],
-            **gather_default_false_values,
+            **gather_default_values,
+            "_": {**default_underscore_gather},
             "suffix": [".gov"],
             "dap": "https://analytics.usa.gov/data/live/sites-extended.csv",
         }
@@ -131,7 +141,8 @@ default_underscore_gather = {
         ]),
         {
             'gatherers': ['censys', 'dap', 'private'],
-            **gather_default_false_values,
+            **gather_default_values,
+            "_": {**default_underscore_gather},
             'suffix': ['.gov'],
             'dap': 'https://analytics.usa.gov/data/live/sites-extended.csv',
             'private': '/path/to/private-research.csv',
@@ -147,7 +158,8 @@ default_underscore_gather = {
         ]),
         {
             'gatherers': ['censys', 'dap', 'private'],
-            **gather_default_false_values,
+            **gather_default_values,
+            "_": {**default_underscore_gather},
             'suffix': ['.gov'],
             'dap': 'https://analytics.usa.gov/data/live/sites-extended.csv',
             'private': '/path/to/private-research.csv',
@@ -162,7 +174,8 @@ default_underscore_gather = {
         ]),
         {
             'gatherers': ['dap'],
-            **gather_default_false_values,
+            **gather_default_values,
+            "_": {**default_underscore_gather},
             'suffix': ['.gov'],
             'dap': 'https://analytics.usa.gov/data/live/sites-extended.csv',
             'ignore_www': True,
@@ -176,7 +189,8 @@ default_underscore_gather = {
         ]),
         {
             'gatherers': ['dap'],
-            **gather_default_false_values,
+            **gather_default_values,
+            "_": {**default_underscore_gather},
             'suffix': ['.gov'],
             'dap': 'https://analytics.usa.gov/data/live/sites-extended.csv',
             'include_parents': True,
@@ -189,7 +203,8 @@ default_underscore_gather = {
         ]),
         {
             'gatherers': ['dap'],
-            **gather_default_false_values,
+            **gather_default_values,
+            "_": {**default_underscore_gather},
             'suffix': ['.gov'],
             'dap': 'https://analytics.usa.gov/data/live/sites-extended.csv',
         }
@@ -202,7 +217,8 @@ default_underscore_gather = {
         ]),
         {
             'gatherers': ['dap'],
-            **gather_default_false_values,
+            **gather_default_values,
+            "_": {**default_underscore_gather},
             'suffix': ['.gov'],
             'dap': 'https://analytics.usa.gov/data/live/sites-extended.csv',
             'debug': True,
@@ -295,8 +311,8 @@ def test_options_for_scan_basic(monkeypatch):
         "_": default_underscore_scan,
         "domains": "example.org",
         "scan": "a11y",
+        **scan_default_values,
         "output": "./",
-        **scan_default_false_values,
     }
 
 
@@ -342,12 +358,13 @@ def test_options_for_scan_lambda_profile_no_lambda(monkeypatch):
             "scan": "a11y",
             "workers": "1",
             "output": "./",
-            **scan_default_false_values,
+            **scan_default_values,
         }
     ),
     (
         "./scan example.org --scan=a11y --output=..",
         {
+            **scan_default_values,
             "_": {
                 "cache_dir": "../cache",
                 "report_dir": "..",
@@ -356,7 +373,6 @@ def test_options_for_scan_lambda_profile_no_lambda(monkeypatch):
             "domains": "example.org",
             "scan": "a11y",
             "output": "..",
-            **scan_default_false_values,
         }
     ),
 ])

--- a/utils/scan_utils.py
+++ b/utils/scan_utils.py
@@ -415,12 +415,33 @@ def build_scan_options_parser() -> ArgumentParser:
     parser.add_argument("--workers", nargs=1,
                         help="Limit parallel threads per-scanner to a number.")
     # TODO: Should workers have a default value?
+    # TODO: Move the scanner-specific argument parsing to each scanner's code.
 
-    parser.add_argument("--a11y_config",
-                        help="Location of pa11y config file (used with a11y scanner.")
+    # a11y:
+    parser.add_argument("--a11y-config",
+                        help="a11y: Location of pa11y config file (used with a11y scanner.")
 
-    parser.add_argument("--a11y_redirects",
-                        help="Location of YAML file with redirects to inform the a11y scanner.")
+    parser.add_argument("--a11y-redirects",
+                        help="a11y: Location of YAML file with redirects to inform the a11y scanner.")
+    # analytics:
+    parser.add_argument("--analytics",
+                        help="analytics: Location of CSV file with participating analytics sites.")
+    # sslyze:
+    parser.add_argument("--sslyze-serial",
+                        help="sslyze: If set, will use a synchronous (single-threaded in-process) scanner. Defaults to true.")
+    parser.add_argument("--sslyze-certs",
+                        help="sslyze: If set, will use the CertificateInfoScanner and return certificate info. Defaults to true.")
+    # trustymail:
+    parser.add_argument("--starttls", help="trustymail: ?")
+    parser.add_argument("--timeout", help="trustymail: ?")
+    parser.add_argument("--smtp-timeout", help="trustymail: ?")
+    parser.add_argument("--smtp-localhost", help="trustymail: ?")
+    parser.add_argument("--smtp-ports", help="trustymail: ?")
+    parser.add_argument("--dns", help="trustymail: ?")
+    parser.add_argument("--no-smtp-cache", help="trustymail: ?")
+    parser.add_argument("--mx", help="trustymail: ?")
+    parser.add_argument("--spf", help="trustymail: ?")
+    parser.add_argument("--dmarc", help="trustymail: ?")
 
     return parser
 

--- a/utils/scan_utils.py
+++ b/utils/scan_utils.py
@@ -416,8 +416,11 @@ def build_scan_options_parser() -> ArgumentParser:
                         help="Limit parallel threads per-scanner to a number.")
     # TODO: Should workers have a default value?
 
-    parser.add_argument("--analytics",
-                        help="Location of CSV file with participating analytics sites.")
+    parser.add_argument("--a11y_config",
+                        help="Location of pa11y config file (used with a11y scanner.")
+
+    parser.add_argument("--a11y_redirects",
+                        help="Location of YAML file with redirects to inform the a11y scanner.")
 
     return parser
 

--- a/utils/scan_utils.py
+++ b/utils/scan_utils.py
@@ -416,6 +416,9 @@ def build_scan_options_parser() -> ArgumentParser:
                         help="Limit parallel threads per-scanner to a number.")
     # TODO: Should workers have a default value?
 
+    parser.add_argument("--analytics",
+                        help="Location of CSV file with participating analytics sites.")
+
     return parser
 
 

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -191,7 +191,7 @@ def build_gather_options_parser(services):
         "Override the 10 minute job timeout (specify in seconds) ",
         "(censys only).",
     ]))
-    parser.add_argument("--output", nargs=1, default="./", help="".join([
+    parser.add_argument("--output", nargs=1, default=["./"], help="".join([
         "Where to output the 'cache/' and 'results/' directories. ",
         "Defaults to './'.",
     ]))
@@ -276,6 +276,14 @@ def options_for_gather():
             if opts.get(scored):
                 opts[gatherer] = opts[scored][0]
                 del opts[scored]
+
+
+    # Derive some options not set directly at CLI:
+    opts["_"] = {
+        "cache_dir": os.path.join(opts.get("output", "./"), "cache"),
+        "report_dir": opts.get("output", "./"),
+        "results_dir": os.path.join(opts.get("output", "./"), "results"),
+    }
 
     # Some of the arguments expect single values on the command line, but those
     # values may contain comma-separated multiple values, so create the

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -277,7 +277,6 @@ def options_for_gather():
                 opts[gatherer] = opts[scored][0]
                 del opts[scored]
 
-
     # Derive some options not set directly at CLI:
     opts["_"] = {
         "cache_dir": os.path.join(opts.get("output", "./"), "cache"),

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -191,7 +191,7 @@ def build_gather_options_parser(services):
         "Override the 10 minute job timeout (specify in seconds) ",
         "(censys only).",
     ]))
-    parser.add_argument("--output", nargs=1, default=["./"], help="".join([
+    parser.add_argument("--output", nargs=1, default="./", help="".join([
         "Where to output the 'cache/' and 'results/' directories. ",
         "Defaults to './'.",
     ]))
@@ -251,6 +251,7 @@ def options_for_gather():
     should_be_singles = [
         "parents",
         "suffix",
+        "output",
     ]
     for service in services:
         should_be_singles.append(service)

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -191,6 +191,10 @@ def build_gather_options_parser(services):
         "Override the 10 minute job timeout (specify in seconds) ",
         "(censys only).",
     ]))
+    parser.add_argument("--output", nargs=1, default=["./"], help="".join([
+        "Where to output the 'cache/' and 'results/' directories. ",
+        "Defaults to './'.",
+    ]))
     return parser
 
 

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -74,7 +74,6 @@ def download(url, destination):
 
     # If it's a gzipped file, ungzip it and replace it
     if headers.get("Content-Encoding") == "gzip":
-        print("hey")
         unzipped_file = filename + ".unzipped"
 
         with gzip.GzipFile(filename, 'rb') as inf:
@@ -269,7 +268,6 @@ def options_for_gather():
     # If any hyphenated gatherers got sent in, override the hyphen-to-underscore
     # conversion that argparse does by default.
     # Also turn the array into a single one, since nargs=1 won't have been set.
-    print(opts)
     for gatherer in opts["gatherers"]:
         if "-" in gatherer:
             scored = gatherer.replace("-", "_")


### PR DESCRIPTION
Gatherer names like `censys-snapshot` were failing, because of argparse's automatic hyphen->underscore conversion. This led to `nargs=1` not being set for them, as well as the `gather` script not matching up the stated source name with the keys in the `options` dict.

This fixes that, and also ditches one of the restrictions around checking whether some flags are gatherer-specific. It seemed unnecessary to keep this mapping maintained over the long run.