### PR TITLE
Ignore pytest cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.pytest_cache
 /lambda/build
 /lambda/envs
 /lambda/*.txt


### PR DESCRIPTION
I get this directory deposited in the project root after running `./test.sh` locally. This git-ignores it.