### PR TITLE
Using PyPI instead of pulling from GitHub

### DIFF
--- a/requirements-scanners.txt
+++ b/requirements-scanners.txt
@@ -9,7 +9,6 @@ trustymail>=0.5.5
 
 # sslyze
 sslyze>=1.4.1
-cryptography
 
 # a11y / csp
 pyyaml

--- a/requirements-scanners.txt
+++ b/requirements-scanners.txt
@@ -2,10 +2,10 @@
 # Requirements used by specific scanners.
 
 # pshtt
-git+https://github.com/dhs-ncats/pshtt.git#egg=pshtt
+pshtt>=0.4.1
 
 # trustymail
-git+https://github.com/dhs-ncats/trustymail.git#egg=trustymail
+trustymail>=0.5.5
 
 # sslyze
 sslyze>=1.4.1


### PR DESCRIPTION
Now that deployment to PyPI is back on track for `pshtt` and `trustymail`, we can use explicit version numbers here instead of just pulling whatever is in `develop`.