### PR TITLE
Adding missing requirement to requirements-lambda.txt

### DIFF
--- a/lambda/requirements-lambda.txt
+++ b/lambda/requirements-lambda.txt
@@ -1,5 +1,6 @@
 # These are the only dependencies which must get packaged
 # into every (Python-based) Lambda container build.
 
-strict-rfc3339
 publicsuffix
+requests
+strict-rfc3339

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,9 @@
 
 ########
-# NOTE: Any requirements which are needed for Python-based Lambda function
-# packaging should also be listed in lambda/requirements-lambda.txt.
-# Those are in the bottom section below.
-
-# Used in scan script
-requests
+# NOTE: Any requirements which are needed for Python-based Lambda
+# function packaging should instead be listed in
+# lambda/requirements-lambda.txt.  This file is imported in the bottom
+# section below.
 
 # Used by parts of domain-scan, but not used inside of Lambda function
 # invocation.


### PR DESCRIPTION
Moving requests from `requirements.txt` to `lambda/requirements-lambda.txt`.

My dhs-ncats/lambda_functions `sslyze` Lambda function was failing at run time because it was missing the `requests` module.