### PR TITLE
Use the correct way to access dict of object

### DIFF
--- a/scanners/analytics.py
+++ b/scanners/analytics.py
@@ -39,7 +39,7 @@ def handle_scanner_args(args, opts) -> Tuple[dict, list]:
     parser = scan_utils.ArgumentParser(prefix_chars="--")
     parser.add_argument("--analytics", nargs=1, required=True)
     parsed, unknown = parser.parse_known_args(args)
-    dicted = parsed.__dict__
+    dicted = vars(parsed)
     should_be_single = ["analytics"]
     dicted = scan_utils.make_values_single(dicted, should_be_single)
     resource = dicted.get("analytics")

--- a/scanners/noop.py
+++ b/scanners/noop.py
@@ -75,7 +75,7 @@ def handle_scanner_args(args, opts) -> Tuple[dict, list]:
     parser = ArgumentParser(prefix_chars="--")
     parser.add_argument("--noop-delay", nargs=1)
     parsed, unknown = parser.parse_known_args(args)
-    dicted = parsed.__dict__
+    dicted = vars(parsed)
     should_be_single = ["noop_delay"]
     dicted = make_values_single(dicted, should_be_single)
     dicted["noop_delay"] = int(dicted["noop_delay"], 10)

--- a/utils/scan_utils.py
+++ b/utils/scan_utils.py
@@ -460,8 +460,7 @@ def options() -> Tuple[dict, list]:
     parser = build_scan_options_parser()
     parsed, unknown = parser.parse_known_args()
 
-    opts = parsed.__dict__
-    opts = {k: opts[k] for k in opts if opts[k] is not None}
+    opts = {k: v for k, v in vars(parsed).items() if v is not None}
 
     if opts.get("lambda_profile") and not opts.get("lambda"):
             raise argparse.ArgumentTypeError(
@@ -489,9 +488,8 @@ def options() -> Tuple[dict, list]:
 
 def make_values_single(dct: dict,
                        should_be_singles: Union[Tuple[str, ...], List[str]]) -> dict:
-    for key in should_be_singles:
-        if key in dct:
-            dct[key] = dct[key][0]
+    for key in (k for k in should_be_singles if k in dct):
+        dct[key] = dct[key][0]
     return dct
 
 

--- a/utils/scan_utils.py
+++ b/utils/scan_utils.py
@@ -486,8 +486,7 @@ def options() -> Tuple[dict, list]:
     return (opts, unknown)
 
 
-def make_values_single(dct: dict,
-                       should_be_singles: Union[Tuple[str, ...], List[str]]) -> dict:
+def make_values_single(dct: dict, should_be_singles: Iterable[str]) -> dict:
     for key in (k for k in should_be_singles if k in dct):
         dct[key] = dct[key][0]
     return dct

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -239,8 +239,8 @@ def options_for_gather():
     for remainder in remaining:
         if remainder.startswith("--") or remainder == ",":
             raise argparse.ArgumentTypeError("%s isn't a valid argument here." % remainder)
-    opts = parsed.__dict__
-    opts = {k: opts[k] for k in opts if opts[k] is not None}
+
+    opts = {k: v for k, v in vars(parsed).items() if v is not None}
 
     """
     The following expect a single argument, but argparse returns lists for them


### PR DESCRIPTION
There is a good way
It is the Pythonic way
We should use that way.

I was lazy in an early iteration of this code and then kept one of the artifacts of that laziness around through later versions/branches. This corrects that by using `vars()` instead of directly accessing the parser object's `__dict__` property.