### PR TITLE
Don't filter domains prefixed with "domain"

### DIFF
--- a/gather
+++ b/gather
@@ -187,7 +187,7 @@ def get_parent_domains(options, cache_dir="./cache"):
     parent_domains = []
     with open(parents, encoding='utf-8', newline='') as csvfile:
         for row in csv.reader(csvfile):
-            if (not row[0]) or (row[0].lower().startswith("domain")):
+            if (not row[0]) or (row[0].lower() == "domain") or (row[0].lower() == "domain name"):
                 continue
             parent_domains.append(row[0].lower())
 

--- a/scan
+++ b/scan
@@ -448,7 +448,7 @@ def add_lambda_details(input_filename, logs_client):
 
     for row in csv.reader(input_file):
         # keep header and add the Lambda detail headers
-        if (row[0].lower().startswith("domain")):
+        if (row[0].lower() == "domain"):
             header = row
             continue
 

--- a/utils/scan_utils.py
+++ b/utils/scan_utils.py
@@ -625,7 +625,7 @@ def _df_path(arg: Path, domain_suffix: Union[str, None]=None) -> Iterable[str]:
     if arg.suffix == ".csv":
         with arg.open(encoding='utf-8', newline='') as csvfile:
             for row in csv.reader(csvfile):
-                if (not row[0]) or (row[0].lower().startswith("domain")):
+                if (not row[0]) or (row[0].lower() == "domain") or (row[0].lower() == "domain name"):
                     continue
                 domain = row[0].lower()
                 if domain_suffix:

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -640,7 +640,7 @@ def load_domains(domain_csv, whole_rows=False):
             row[0] = row[0].lower()
 
             # Skip any header row.
-            if (not domains) and (row[0].startswith("domain")):
+            if (not domains) and ((row[0] == "domain") or (row[0] == "domain name")):
                 continue
 
             if whole_rows:


### PR DESCRIPTION
At least `domains.dotgov.gov` was getting filtered out at scan-time due to some hacky logic at detecting header rows. This makes header row recognition more precise.