### PR TITLE
Improving sslyze caching for SMTP scans

### DIFF
--- a/scanners/sslyze.py
+++ b/scanners/sslyze.py
@@ -137,7 +137,8 @@ def scan(domain, environment, options):
 
     # Return the scan results together with the already-cached results (if
     # there were any)
-    return retVal.extend(environment['cached_data'])
+    retVal.extend(environment['cached_data'])
+    return retVal
 
 
 # Given a response dict, turn it into CSV rows.

--- a/scanners/sslyze.py
+++ b/scanners/sslyze.py
@@ -81,6 +81,10 @@ def init_domain(domain, environment, options):
         # multiple government domains often use the same SMTP servers, so if
         # the user specified the --cache flag then it makes sense to check if
         # we have already hit this mail server when testing a different domain.
+        #
+        # Note that as the sslyze cache grows in size sslyze SMTP scans run
+        # slower because reading all the JSON files in the cache takes time.
+        # There are considerably fewer errors in the scans, though.
         cache = None
         if options.get('cache'):
             cache = utils.find_data_in_sslyze_cache(hostname, port, cache_dir=cache_dir)

--- a/scanners/sslyze.py
+++ b/scanners/sslyze.py
@@ -44,7 +44,8 @@ lambda_support = True
 # support STARTTLS so we can scan them.
 def init_domain(domain, environment, options):
     hosts_to_scan = []
-    cache_dir = options.get("_", {}).get("cache_dir", "./cache")
+    cached_data = []
+    cache_dir = options.get('_', {}).get('cache_dir', './cache')
 
     # If we have pshtt data, skip domains which pshtt saw as not
     # supporting HTTPS at all.
@@ -54,7 +55,7 @@ def init_domain(domain, environment, options):
         # If we have pshtt data and it says canonical endpoint uses
         # www and the given domain is bare, add www.
         if utils.domain_uses_www(domain, cache_dir=cache_dir):
-            hostname = "www.%s" % domain
+            hostname = 'www.%s' % domain
         else:
             hostname = domain
 
@@ -69,16 +70,33 @@ def init_domain(domain, environment, options):
     mail_servers_to_test = utils.domain_mail_servers_that_support_starttls(domain, cache_dir=cache_dir)
     for mail_server in mail_servers_to_test:
         hostname_and_port = mail_server.split(':')
-        hosts_to_scan.append({
-            'hostname': hostname_and_port[0],
-            'port': hostname_and_port[1],
-            'starttls_smtp': True
-        })
+        hostname = hostname_and_port[0]
+        port = hostname_and_port[1]
+        # Check if we already have results for this mail server, possibly from
+        # a different domain.
+        #
+        # I have found that SMTP servers (as compared to HTTP/HTTPS servers)
+        # are MUCH more sensitive to having multiple connections made to them.
+        # In testing the various cyphers we make a lot of connections, and
+        # multiple government domains often use the same SMTP servers, so if
+        # the user specified the --cache flag then it makes sense to check if
+        # we have already hit this mail server when testing a different domain.
+        cache = None
+        if options.get('cache'):
+            cache = utils.find_data_in_sslyze_cache(hostname, port, cache_dir=cache_dir)
+        if cache is None:
+            hosts_to_scan.append({
+                'hostname': hostname,
+                'port': port,
+                'starttls_smtp': True
+            })
+        else:
+            cached_data.append(cache)
 
     if not hosts_to_scan:
         logging.warn('\tNo hosts to scan for {}'.format(domain))
 
-    return {'hosts_to_scan': hosts_to_scan}
+    return {'hosts_to_scan': hosts_to_scan, 'cached_data': cached_data}
 
 
 # Run sslyze on the given domain.
@@ -117,7 +135,9 @@ def scan(domain, environment, options):
 
         retVal.append(data)
 
-    return retVal
+    # Return the scan results together with the already-cached results (if
+    # there were any)
+    return retVal.extend(environment['cached_data'])
 
 
 # Given a response dict, turn it into CSV rows.

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -14,6 +14,7 @@ import logging
 import datetime
 import strict_rfc3339
 import codecs
+from glob import iglob
 from itertools import chain
 from urllib.error import URLError
 
@@ -590,6 +591,25 @@ def domain_mail_servers_that_support_starttls(domain, cache_dir="./cache"):
             retVal = starttls_results.split(', ')
 
     return retVal
+
+
+def find_data_in_sslyze_cache(hostname, port, cache_dir="./cache"):
+    """Finds data for the specified hostname and port in the sslyze cache.
+
+    Searches the sslyze cache for existing data about the specified
+hostname and port.  If such data is found then it is returned;
+otherwise, None is returned."""
+    filename_iter = iglob('{}/sslyze/*.json'.format(cache_dir))
+    for filename in filename_iter:
+        # Extract the domain from the filename
+        domain = os.path.splitext(os.path.basename(filename))[0]
+        
+        data = data_for(domain, 'sslyze', cache_dir)
+        for host_data in data:
+            if host_data['hostname'] == hostname and host_data['port'] == str(port):
+                return host_data
+
+    return None
 
 
 # Check whether we have HTTP behavior data cached for a domain.

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -605,9 +605,10 @@ otherwise, None is returned."""
         domain = os.path.splitext(os.path.basename(filename))[0]
         
         data = data_for(domain, 'sslyze', cache_dir)
-        for host_data in data:
-            if host_data['hostname'] == hostname and host_data['port'] == str(port):
-                return host_data
+        if data is not None:
+            for host_data in data:
+                if host_data['hostname'] == hostname and host_data['port'] == str(port):
+                    return host_data
 
     return None
 


### PR DESCRIPTION
This pull request adds code that, when running an sslyze scan against an SMTP server, checks the sslyze cache to see if we already have results for the SMTP server, possibly from a different domain.

I have found that SMTP servers (as compared to HTTP/HTTPS servers) are _much_ more sensitive to having multiple connections made to them.  In testing the various ciphers sslyze makes a lot of connections, and multiple domains often use the same SMTP servers, so if the user specified the {{--cache}} flag then it makes sense to check if we have already scanned this mail server when testing a different domain.

Note that as the sslyze cache grows in size sslyze SMTP scans run slower because reading all the JSON files in the cache takes time.  There are considerably fewer errors in the scans, though.