### PR TITLE
Fixing a bug in the Dockerfile due to changing Google Chrome requirements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,7 +52,7 @@ RUN \
       npm \
       # Chrome dependencies
       fonts-liberation \
-      libappindicator1 \
+      libappindicator3-1 \
       libasound2 \
       libatk-bridge2.0-0 \
       libgtk-3-0 \


### PR DESCRIPTION
Editing the `Dockerfile` since Google Chrome now requires `libappindicator3-1` instead of `libappindicator1`.