### PR TITLE
Adding package.json to repo

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "domain-scan-headless-lambda",
+  "description": "Dependencies for building Lambda containers for headless Chrome in domain-scan.",
+  "dependencies": {
+    "puppeteer": "^1.0.0",
+    "tar": "^4.0.1"
+  },
+  "devDependencies": {
+    "babel-cli": "^6.26.0",
+    "babel-preset-env": "^1.6.0"
+  }
+}


### PR DESCRIPTION
This was meant to be included way back in #195, but the `*.json` exclude in `.gitignore` silently kept it out, so I didn't realize it until I tried to use this another workstation.