### PR TITLE
Updating to use the latest trustymail from PyPI

### DIFF
--- a/requirements-scanners.txt
+++ b/requirements-scanners.txt
@@ -5,7 +5,7 @@
 pshtt>=0.4.2
 
 # trustymail
-trustymail>=0.5.5
+trustymail>=0.5.7
 
 # sslyze
 sslyze>=1.4.2


### PR DESCRIPTION
There were a few minor changes in `trustymail` that resulted in a version bump.  Here I update `requirement-scanners.txt` to use the latest version of `trustymail` from PyPI.