### PR TITLE
Relying on Python 3.6+ now

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,44 +2,6 @@
 
 version: 2
 jobs:
-  build_35:
-    docker:
-      - image: circleci/python:3.5
-
-    steps:
-    - checkout
-
-    # Download and cache dependencies
-    - restore_cache:
-        keys:
-        - v1-python35-dependencies-{{ checksum "requirements.txt" }}
-        # fallback to using the latest cache if no exact match is found
-        - v1-python35-dependencies-
-
-    - run:
-        name: install dependencies
-        command: |
-          python3 -m venv venv
-          . venv/bin/activate
-          pip install --upgrade setuptools
-          pip install flake8
-          pip install -r requirements.txt
-
-    - save_cache:
-        paths:
-          - ./venv
-        key: v1-python35-dependencies-{{ checksum "requirements.txt" }}
-
-    - run:
-        name: run tests
-        command: |
-          . venv/bin/activate
-          ./test.sh
-
-    - store_artifacts:
-        path: test-reports
-        destination: test-reports
-
   build_36:
     docker:
       - image: circleci/python:3.6
@@ -82,5 +44,4 @@ workflows:
   version: 2
   build_and_test:
     jobs:
-      - build_35
       - build_36

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ There is also built-in support for using **headless Chrome** to efficiently meas
 
 ### Requirements
 
-`domain-scan` requires **Python 3.5 and up**.
+`domain-scan` requires **Python 3.6 and up**.
 
 To install **core dependencies**:
 


### PR DESCRIPTION
Newer versions of `domain-scan` now rely on Python 3.6+, due to the use of `Path.resolve()` that was added in some recent-ish PRs. Since upgrading from 3.5->3.6 should be pretty painless these days, it seems easier to just bump the documented minimum requirement to match.

Fixes #261.