### PR TITLE
Cast the port string into an integer

### DIFF
--- a/scanners/sslyze.py
+++ b/scanners/sslyze.py
@@ -71,7 +71,7 @@ def init_domain(domain, environment, options):
         hostname_and_port = mail_server.split(':')
         hosts_to_scan.append({
             'hostname': hostname_and_port[0],
-            'port': hostname_and_port[1],
+            'port': int(hostname_and_port[1]),
             'starttls_smtp': True
         })
 


### PR DESCRIPTION
sslyze 2.0 is pickier about types, and passing the port as a string here was causing sslyze to fail.

For HTTPS scanning the port is not specified (the default of 443 is used), so this bug was only impacting folks like me who are using sslyze against other ports.