### PR TITLE
Change all occurances of logging.warn() to logging.warning().

### DIFF
--- a/gather
+++ b/gather
@@ -149,7 +149,7 @@ def run(options=None, cache_dir="./cache", results_dir="./results"):
     if options.get("sort"):
         utils.sort_csv(gathered_filename)
 
-    logging.warn("Results written to CSV.")
+    logging.warning("Results written to CSV.")
 
     # Save metadata.
     end_time = utils.local_now()

--- a/gatherers/censys.py
+++ b/gatherers/censys.py
@@ -45,8 +45,8 @@ class Gatherer(Gatherer):
         credentials = load_credentials()
 
         if credentials is None:
-            logging.warn("No BigQuery credentials provided.")
-            logging.warn("Set BIGQUERY_CREDENTIALS or BIGQUERY_CREDENTIALS_PATH environment variables.")
+            logging.warning("No BigQuery credentials provided.")
+            logging.warning("Set BIGQUERY_CREDENTIALS or BIGQUERY_CREDENTIALS_PATH environment variables.")
             exit(1)
 
         # When using this form of instantiation, the client won't pull
@@ -70,7 +70,7 @@ class Gatherer(Gatherer):
         # Reuse of cached data can be turned on with --cache.
         cache = self.options.get("cache", False)
         if (cache is True) and os.path.exists(download_path):
-            logging.warn("Using cached download data.")
+            logging.warning("Using cached download data.")
 
         # But by default, fetch new data from the BigQuery API,
         # and write it to the expected download location.
@@ -78,7 +78,7 @@ class Gatherer(Gatherer):
             # Ensure cache destination exists.
             utils.mkdir_p(os.path.dirname(download_path))
 
-            logging.warn("Kicking off SQL query job.")
+            logging.warning("Kicking off SQL query job.")
 
             rows = None
 
@@ -89,14 +89,14 @@ class Gatherer(Gatherer):
                 iterator = query_job.result(timeout=timeout)
                 rows = list(iterator)
             except google.api_core.exceptions.Forbidden:
-                logging.warn("Access denied to Censys' BigQuery tables.")
+                logging.warning("Access denied to Censys' BigQuery tables.")
             except:
-                logging.warn(utils.format_last_exception())
-                logging.warn("Error talking to BigQuery, aborting.")
+                logging.warning(utils.format_last_exception())
+                logging.warning("Error talking to BigQuery, aborting.")
 
             # At this point, the job is complete and we need to download
             # the resulting CSV URL in results_url.
-            logging.warn("Caching results of SQL query.")
+            logging.warning("Caching results of SQL query.")
 
             download_file = open(download_path, 'w', newline='')
             download_writer = csv.writer(download_file)

--- a/gatherers/rdns.py
+++ b/gatherers/rdns.py
@@ -33,12 +33,12 @@ class Gatherer(Gatherer):
         path = self.options.get("rdns")
 
         if path is None:
-            logging.warn("--rdns is required to be a path to a local file.")
+            logging.warning("--rdns is required to be a path to a local file.")
             exit(1)
 
         # May become useful to allow URLs in future.
         if path.startswith("http:") or path.startswith("https:"):
-            logging.warn("--rdns is required to be a path to a local file.")
+            logging.warning("--rdns is required to be a path to a local file.")
             exit(1)
 
         with open(path) as lines:

--- a/gatherers/url.py
+++ b/gatherers/url.py
@@ -15,7 +15,7 @@ class Gatherer(Gatherer):
         url = self.options.get(name)
 
         if url is None:
-            logging.warn("A --url is required. (Can be a local path.)")
+            logging.warning("A --url is required. (Can be a local path.)")
             exit(1)
 
         # remote URL

--- a/scan
+++ b/scan
@@ -169,7 +169,7 @@ def scan_domains(scanners: List[ModuleType], domains: Path,
             init = scanner.init(environment, options)  # type: ignore
             # If a scanner's init() function returns false, stop entirely.
             if init is False:
-                logging.warn("[%s] Scanner init function returned false!  Bailing."
+                logging.warning("[%s] Scanner init function returned false!  Bailing."
                              % handles[name]['name'])
                 exit(1)
 
@@ -207,7 +207,7 @@ def scan_domains(scanners: List[ModuleType], domains: Path,
 
     # Sleeping's not ideal, but no better idea right now.
     if get_lambda_details:
-        logging.warn("\tWaiting %is for logs to show up in CloudWatch..." %
+        logging.warning("\tWaiting %is for logs to show up in CloudWatch..." %
                      LAMBDA_LOG_DELAY)
         time.sleep(LAMBDA_LOG_DELAY)
 
@@ -221,7 +221,7 @@ def scan_domains(scanners: List[ModuleType], domains: Path,
             add_lambda_details(handle['filename'],
                                options["_"]["lambda_options"]["logs_client"])
 
-    logging.warn("Results written to CSV.")
+    logging.warning("Results written to CSV.")
 
     # Save metadata.
     end_time = scan_utils.local_now()
@@ -253,7 +253,7 @@ def perform_scan(params: Tuple[Any, str, dict, dict, dict]):
     assert name == handles[name]['name']  # Sanity check
 
     try:
-        logging.warn("[%s][%s] Running scan..." % (domain, name))
+        logging.warning("[%s][%s] Running scan..." % (domain, name))
 
         data = None
 
@@ -276,7 +276,7 @@ def perform_scan(params: Tuple[Any, str, dict, dict, dict]):
         )
 
         if (options.get("cache")) and (os.path.exists(domain_cache)):
-            logging.warn("\tUsing cached scan response.")
+            logging.warning("\tUsing cached scan response.")
             raw = scan_utils.read(domain_cache)
             data = json.loads(raw)
             if (data.__class__ is dict) and data.get('invalid'):
@@ -312,7 +312,7 @@ def perform_scan(params: Tuple[Any, str, dict, dict, dict]):
         # Always print errors.
         if len(meta['errors']) > 0:
             for error in meta['errors']:
-                logging.warn("\t%s" % error)
+                logging.warning("\t%s" % error)
 
         # If --meta wasn't requested, throw it all away.
         if not options.get("meta", False):
@@ -322,7 +322,7 @@ def perform_scan(params: Tuple[Any, str, dict, dict, dict]):
             rows, domain, scan_utils.base_domain_for(domain, cache_dir=cache_dir),
             scanner, handles[name]['writer'], meta=meta)
     except:
-        logging.warn(scan_utils.format_last_exception())
+        logging.warning(scan_utils.format_last_exception())
 
 
 ###
@@ -332,7 +332,7 @@ def perform_scan(params: Tuple[Any, str, dict, dict, dict]):
 #
 # Let all errors bubble up to perform_scan.
 def perform_local_scan(scanner, domain, handles, environment, options, meta):
-    logging.warn("\tExecuting local scan...")
+    logging.warning("\tExecuting local scan...")
 
     scanner_name = scanner.__name__.split(".")[-1]  # e.g. 'pshtt'
 
@@ -362,7 +362,7 @@ def perform_local_scan(scanner, domain, handles, environment, options, meta):
 # Catch some Lambda-specific exceptions around the invoke call,
 # but otherwise allow exceptions to bubble up to perform_scan.
 def perform_lambda_scan(scanner, domain, handles, environment, options, meta):
-    logging.warn("\tExecuting Lambda scan...")
+    logging.warning("\tExecuting Lambda scan...")
 
     scanner_name = scanner.__name__.split(".")[-1]  # e.g. 'pshtt'
 
@@ -435,7 +435,7 @@ def perform_lambda_scan(scanner, domain, handles, environment, options, meta):
 # this function relatively stateless (only relying on info in the
 # Lambda detail fields) to make parallelization/refactoring easier.
 def add_lambda_details(input_filename, logs_client):
-    logging.warn("Fetching more Lambda details for %s..." % input_filename)
+    logging.warning("Fetching more Lambda details for %s..." % input_filename)
 
     input_file = open(input_filename, encoding='utf-8', newline='')
     tmp_filename = "%s.tmp" % input_filename
@@ -457,7 +457,7 @@ def add_lambda_details(input_filename, logs_client):
         for i, cell in enumerate(row):
             dict_row[header[i]] = cell
 
-        logging.warn("[%s][%s] Fetching Lambda details from logs..." % (row[0], input_filename))
+        logging.warning("[%s][%s] Fetching Lambda details from logs..." % (row[0], input_filename))
         details = fetch_lambda_details(dict_row, logs_client)
 
         # Matches order of LAMBDA_DETAIL_HEADERS
@@ -510,7 +510,7 @@ def fetch_lambda_details(dict_row, logs_client):
     except:
         exception = scan_utils.format_last_exception()
         lambda_fields['errors'] = ("Unknown exception: %s" % exception)
-        logging.warn(exception)
+        logging.warning(exception)
         return lambda_fields
 
     if events and events.get('events'):
@@ -530,7 +530,7 @@ def fetch_lambda_details(dict_row, logs_client):
         lambda_fields['memory_used'] = values[4]
     else:
         lambda_fields["errors"] = "No logs found for this task."
-        logging.warn("\tNo logs found for (group, stream, task): %s, %s, %s" % (log_group_name, log_stream_name, request_id))
+        logging.warning("\tNo logs found for (group, stream, task): %s, %s, %s" % (log_group_name, log_stream_name, request_id))
 
     return lambda_fields
 

--- a/scanners/csp.py
+++ b/scanners/csp.py
@@ -53,7 +53,7 @@ def scan(domain, environment, options):
     csp_set = False
     if "content-security-policy" in response.headers:
         csp_set = True
-    logging.warn("Complete!")
+    logging.warning("Complete!")
     return {
         'csp_set': csp_set
     }

--- a/scanners/headless/local_bridge.py
+++ b/scanners/headless/local_bridge.py
@@ -25,13 +25,13 @@ def headless_scan(scanner_name, domain, environment, options):
     )
 
     if not raw:
-        logging.warn("\tError calling out to %s.js, skipping." % scanner_name)
+        logging.warning("\tError calling out to %s.js, skipping." % scanner_name)
         return None
 
     try:
         data = scan_utils.from_json(raw)
     except json.decoder.JSONDecodeError:
-        logging.warn("\tError inside %s.js, skipping. Error below:\n\n%s" % (scanner_name, raw))
+        logging.warning("\tError inside %s.js, skipping. Error below:\n\n%s" % (scanner_name, raw))
         return None
 
     return data

--- a/scanners/noop.py
+++ b/scanners/noop.py
@@ -42,7 +42,7 @@ def scan(domain: str, environment: dict, options: dict) -> dict:
 
     # Perform the "task".
     complete = True
-    logging.warn("Complete!")
+    logging.warning("Complete!")
 
     return {
         'complete': complete,

--- a/scanners/noopabc.py
+++ b/scanners/noopabc.py
@@ -35,7 +35,7 @@ class Scanner(ScannerABC):
 
         # Perform the "task".
         complete = True
-        logging.warn("Complete!")
+        logging.warning("Complete!")
 
         return {
             'complete': complete,

--- a/scanners/pshtt.py
+++ b/scanners/pshtt.py
@@ -26,7 +26,7 @@ lambda_suffix_path = "./cache/public-suffix-list.txt"
 
 # Download third party data once, at the top of the scan.
 def init(environment, options):
-    logging.warn("[pshtt] Downloading third party data...")
+    logging.warning("[pshtt] Downloading third party data...")
 
     # In local environments, download latest PSL, cache in-memory.
     if environment['scan_method'] == "local":

--- a/scanners/sslyze.py
+++ b/scanners/sslyze.py
@@ -49,7 +49,7 @@ def init_domain(domain, environment, options):
     # If we have pshtt data, skip domains which pshtt saw as not
     # supporting HTTPS at all.
     if utils.domain_doesnt_support_https(domain, cache_dir=cache_dir):
-        logging.warn('\tHTTPS not supported for {}'.format(domain))
+        logging.warning('\tHTTPS not supported for {}'.format(domain))
     else:
         # If we have pshtt data and it says canonical endpoint uses
         # www and the given domain is bare, add www.
@@ -76,7 +76,7 @@ def init_domain(domain, environment, options):
         })
 
     if not hosts_to_scan:
-        logging.warn('\tNo hosts to scan for {}'.format(domain))
+        logging.warning('\tNo hosts to scan for {}'.format(domain))
 
     return {'hosts_to_scan': hosts_to_scan}
 
@@ -109,7 +109,7 @@ def scan(domain, environment, options):
         # Error condition.
         if response is None:
             error = "No valid target for scanning, couldn't connect."
-            logging.warn(error)
+            logging.warning(error)
             data['errors'].append(error)
 
         # Join all errors into a string before returning.
@@ -445,11 +445,11 @@ def init_sslyze(hostname, port, starttls_smtp, options, sync=False):
         server_tester = ServerConnectivityTester(hostname=hostname, port=port, tls_wrapped_protocol=tls_wrapped_protocol)
         server_info = server_tester.perform(network_timeout=network_timeout)
     except ServerConnectivityError as err:
-        logging.warn("\tServer connectivity not established during test.")
+        logging.warning("\tServer connectivity not established during test.")
         return None, None
     except Exception as err:
         utils.notify(err)
-        logging.warn("\tUnknown exception when performing server connectivity info.")
+        logging.warning("\tUnknown exception when performing server connectivity info.")
         return None, None
 
     if sync:
@@ -486,7 +486,7 @@ def scan_serial(scanner, server_info, data, options):
             certs = scanner.run_scan_command(server_info, CertificateInfoScanCommand())
         # Let generic exceptions bubble up.
         except idna.core.InvalidCodepoint:
-            logging.warn(utils.format_last_exception())
+            logging.warning(utils.format_last_exception())
             data['errors'].append("Invalid certificate/OCSP for this domain.")
             certs = None
     else:
@@ -508,12 +508,12 @@ def scan_parallel(scanner, server_info, data, options):
         except OSError as err:
             text = ("OSError - likely too many processes and open files.")
             data['errors'].append(text)
-            logging.warn("%s\n%s" % (text, utils.format_last_exception()))
+            logging.warning("%s\n%s" % (text, utils.format_last_exception()))
             return None, None, None, None, None, None, None
         except Exception as err:
             text = ("Unknown exception queueing sslyze command.\n%s" % utils.format_last_exception())
             data['errors'].append(text)
-            logging.warn(text)
+            logging.warning(text)
             return None, None, None, None, None, None, None
 
     # Initialize commands and result containers
@@ -536,7 +536,7 @@ def scan_parallel(scanner, server_info, data, options):
         try:
             if isinstance(result, PluginRaisedExceptionScanResult):
                 error = ("Scan command failed: %s" % result.as_text())
-                logging.warn(error)
+                logging.warning(error)
                 data['errors'].append(error)
                 return None, None, None, None, None, None, None
 
@@ -556,7 +556,7 @@ def scan_parallel(scanner, server_info, data, options):
                 certs = result
             else:
                 error = "Couldn't match scan result with command! %s" % result
-                logging.warn("\t%s" % error)
+                logging.warning("\t%s" % error)
                 data['errors'].append(error)
                 was_error = True
 
@@ -564,7 +564,7 @@ def scan_parallel(scanner, server_info, data, options):
             was_error = True
             text = ("Exception inside async scanner result processing.\n%s" % utils.format_last_exception())
             data['errors'].append(text)
-            logging.warn("\t%s" % text)
+            logging.warning("\t%s" % text)
 
     # There was an error during async processing.
     if was_error:

--- a/scanners/trustymail.py
+++ b/scanners/trustymail.py
@@ -68,7 +68,7 @@ def scan(domain, environment, options):
     data = tmail.scan(domain, timeout, smtp_timeout, smtp_localhost, smtp_ports, smtp_cache, scan_types, dns_hostnames).generate_results()
 
     if not data:
-        logging.warn("\ttrustymail scan failed, skipping.")
+        logging.warning("\ttrustymail scan failed, skipping.")
 
     # Reset the logging level
     logging.getLogger().setLevel(old_log_level)

--- a/utils/scan_utils.py
+++ b/utils/scan_utils.py
@@ -126,9 +126,9 @@ def scan(command: List[str], env: dict=None,
         if exc.returncode in allowed_return_codes:
             return str(exc.stdout, encoding='UTF-8')
         else:
-            logging.warn("Error running %s." % (str(command)))
-            logging.warn("Error running %s." % (str(exc.output)))
-            logging.warn(format_last_exception())
+            logging.warning("Error running %s." % (str(command)))
+            logging.warning("Error running %s." % (str(exc.output)))
+            logging.warning(format_last_exception())
             return None
 
 
@@ -140,8 +140,8 @@ def try_command(command):
                               stderr=subprocess.DEVNULL)
         return True
     except subprocess.CalledProcessError:
-        logging.warn(format_last_exception())
-        logging.warn("No command found: %s" % (str(command)))
+        logging.warning(format_last_exception())
+        logging.warning("No command found: %s" % (str(command)))
         return False
 # /Command Line Conveniences #
 
@@ -180,7 +180,7 @@ def configure_logging(options: Union[dict, None]=None) -> None:
 # This loads the whole thing into memory: it's not a great solution for
 # super-large lists of domains.
 def sort_csv(input_filename):
-    logging.warn("Sorting %s..." % input_filename)
+    logging.warning("Sorting %s..." % input_filename)
 
     input_file = open(input_filename, encoding='utf-8', newline='')
     tmp_filename = "%s.tmp" % input_filename
@@ -302,7 +302,7 @@ def base_domain_for(subdomain, cache_dir="./cache"):
         suffix_list, discard = load_suffix_list(cache_dir=cache_dir)
 
     if suffix_list is None:
-        logging.warn("Error downloading the PSL.")
+        logging.warning("Error downloading the PSL.")
         exit(1)
 
     return suffix_list.get_public_suffix(subdomain)
@@ -325,7 +325,7 @@ def load_suffix_list(cache_dir="./cache"):
         try:
             cache_file = publicsuffix.fetch()
         except URLError as err:
-            logging.warn("Unable to download the Public Suffix List...")
+            logging.warning("Unable to download the Public Suffix List...")
             logging.debug("{}".format(err))
             return None, None
 

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -411,8 +411,8 @@ def try_command(command):
                               stderr=subprocess.DEVNULL)
         return True
     except subprocess.CalledProcessError:
-        logging.warn(format_last_exception())
-        logging.warn("No command found: %s" % (str(command)))
+        logging.warning(format_last_exception())
+        logging.warning("No command found: %s" % (str(command)))
         return False
 
 
@@ -428,9 +428,9 @@ def scan(command, env=None, allowed_return_codes=[]):
         if exc.returncode in allowed_return_codes:
             return str(exc.stdout, encoding='UTF-8')
         else:
-            logging.warn("Error running %s." % (str(command)))
-            logging.warn("Error running %s." % (str(exc.output)))
-            logging.warn(format_last_exception())
+            logging.warning("Error running %s." % (str(command)))
+            logging.warning("Error running %s." % (str(exc.output)))
+            logging.warning(format_last_exception())
             return None
 
 # Turn shell on, when shell=False won't work.
@@ -441,7 +441,7 @@ def unsafe_execute(command):
         response = subprocess.check_output(command, shell=True)
         return str(response, encoding='UTF-8')
     except subprocess.CalledProcessError:
-        logging.warn("Error running %s." % (str(command)))
+        logging.warning("Error running %s." % (str(command)))
         return None
 
 # Predictable cache path for a domain and operation.
@@ -501,7 +501,7 @@ def base_domain_for(subdomain, cache_dir="./cache"):
         suffix_list, discard = load_suffix_list(cache_dir=cache_dir)
 
     if suffix_list is None:
-        logging.warn("Error downloading the PSL.")
+        logging.warning("Error downloading the PSL.")
         exit(1)
 
     return suffix_list.get_public_suffix(subdomain)
@@ -524,7 +524,7 @@ def load_suffix_list(cache_dir="./cache"):
         try:
             cache_file = publicsuffix.fetch()
         except URLError as err:
-            logging.warn("Unable to download the Public Suffix List...")
+            logging.warning("Unable to download the Public Suffix List...")
             logging.debug("{}".format(err))
             return None, None
 
@@ -654,7 +654,7 @@ def load_domains(domain_csv, whole_rows=False):
 # This loads the whole thing into memory: it's not a great solution for
 # super-large lists of domains.
 def sort_csv(input_filename):
-    logging.warn("Sorting %s..." % input_filename)
+    logging.warning("Sorting %s..." % input_filename)
 
     input_file = open(input_filename, encoding='utf-8', newline='')
     tmp_filename = "%s.tmp" % input_filename


### PR DESCRIPTION
`logging.warn()` has long been deprecated, and it causes python 3.7 prints a gazillion warning messages.