### PR TITLE
Remove now-broken hack and replace with proper solution

### DIFF
--- a/scan
+++ b/scan
@@ -43,13 +43,11 @@ def set_aws_credentials(options):
 
     invoke_config = botocore.config.Config(
         max_pool_connections=global_max_workers,
-        connect_timeout=300, read_timeout=300
+        connect_timeout=300,
+        read_timeout=300,
+        retries={'max_attempts': 0}
     )
     invoke_client = lambda_session.client('lambda', config=invoke_config)
-
-    # hack to disable automatic retries for Lambda invocations
-    # https://github.com/boto/boto3/issues/1104
-    invoke_client.meta.events._unique_id_handlers['retry-config-lambda']['handler']._checker.__dict__['_max_attempts'] = 0
 
     logs_config = botocore.config.Config(max_pool_connections=global_max_workers)
     logs_client = lambda_session.client('logs', config=logs_config)


### PR DESCRIPTION
Originally [a hack was put in place to disable automatic Lambda retries](https://github.com/boto/boto3/issues/1104) because `boto3` lacked support for this.  Unfortunately this hack no longer works with the latest `boto3` code because it touches internal variables that apparently have been removed or renamed.  Fortunately, though, [support for disabling automatic retries has been added](https://github.com/boto/botocore/pull/1260).