### PR TITLE
Use latest trustymail

### DIFF
--- a/requirements-scanners.txt
+++ b/requirements-scanners.txt
@@ -5,7 +5,7 @@
 pshtt>=0.5.1
 
 # trustymail
-trustymail>=0.6.1
+trustymail>=0.6.2
 
 # sslyze
 sslyze>=2.0.1


### PR DESCRIPTION
The latest trustymail (0.6.2) fixes a bug where a domain was being labeled "not live" if a `dns.resolver.NoNameservers` or `dns.resolver.NXDOMAIN` exception was thrown when performing the DNS query to check the DMARC record.  The issue is that the DNS query to check the DMARC record queries `_dmarc.domain.gov` and not the domain itself. 
 The domain itself could well be live even if `_dmarc.domain.gov` does not exist.

We turned up a case where this behavior made a difference in the BOD-18-01 scanning.