### PR TITLE
Update to the latest trustymail

### DIFF
--- a/requirements-scanners.txt
+++ b/requirements-scanners.txt
@@ -5,7 +5,7 @@
 pshtt>=0.5.1
 
 # trustymail
-trustymail>=0.6.2
+trustymail>=0.6.3
 
 # sslyze
 sslyze>=2.0.1


### PR DESCRIPTION
The latest trustymail no longer treats certain "ambiguity warning" conditions as errors when checking SPF records.  These are conditions such as using the `mx` mechanism in the SPF record without listing any `MX` records for the domain.

See dhs-ncats/trustymail#96 for details.