### PR TITLE
Update to use the latest version of pshtt

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,4 +1,4 @@
 [flake8]
-ignore = E252,E501,F999,E722,W605
+ignore = E252,E501,F999,E722,W504,W605
 max-line-length = 100
 exclude = .git,.venv,.venv-prod,__pycache__,venv,cache,lambda

--- a/.flake8
+++ b/.flake8
@@ -1,4 +1,4 @@
 [flake8]
-ignore = E501,F999,E722
+ignore = E252,E501,F999,E722,W605
 max-line-length = 100
 exclude = .git,.venv,.venv-prod,__pycache__,venv,cache,lambda

--- a/gatherers/rdns.py
+++ b/gatherers/rdns.py
@@ -19,12 +19,12 @@ from gatherers.gathererabc import Gatherer
 # Best-effort filter for hostnames which are just reflected IPs.
 # IP addresses often use dots or dashes.
 # Some also start with "u-" before the IP address.
-ip_filter = re.compile("^(\w+[\-\.]?)?\d+[\-\.]\d+[\-\.]\d+[\-\.]\d+")
+ip_filter = re.compile(r"^(\w+[\-\.]?)?\d+[\-\.]\d+[\-\.]\d+[\-\.]\d+")
 
 # Best-effort filter for hostnames with just numbers on the base domain.
 # (Note: this won't work for fed.us subdomains, but that's okay, this
 # is just a best-effort to cut down noise.)
-number_filter = re.compile("^[\d\-]+\.")
+number_filter = re.compile(r"^[\d\-]+\.")
 
 
 class Gatherer(Gatherer):

--- a/requirements-scanners.txt
+++ b/requirements-scanners.txt
@@ -2,7 +2,7 @@
 # Requirements used by specific scanners.
 
 # pshtt
-pshtt>=0.5.1
+pshtt>=0.5.2
 
 # trustymail
 trustymail>=0.6.3

--- a/scanners/pshtt.py
+++ b/scanners/pshtt.py
@@ -132,4 +132,4 @@ headers = [
 
 
 def format_domain(domain):
-    return re.sub("^(https?://)?(www\.)?", "", domain)
+    return re.sub(r"^(https?://)?(www\.)?", "", domain)

--- a/scanners/sslyze.py
+++ b/scanners/sslyze.py
@@ -444,7 +444,7 @@ def init_sslyze(hostname, port, starttls_smtp, options, sync=False):
         # logging.debug("\tTesting connectivity with timeout of %is." % network_timeout)
         server_tester = ServerConnectivityTester(hostname=hostname, port=port, tls_wrapped_protocol=tls_wrapped_protocol)
         server_info = server_tester.perform(network_timeout=network_timeout)
-    except ServerConnectivityError as err:
+    except ServerConnectivityError:
         logging.warning("\tServer connectivity not established during test.")
         return None, None
     except Exception as err:
@@ -505,12 +505,12 @@ def scan_parallel(scanner, server_info, data, options):
     def queue(command):
         try:
             return scanner.queue_scan_command(server_info, command)
-        except OSError as err:
+        except OSError:
             text = ("OSError - likely too many processes and open files.")
             data['errors'].append(text)
             logging.warning("%s\n%s" % (text, utils.format_last_exception()))
             return None, None, None, None, None, None, None
-        except Exception as err:
+        except Exception:
             text = ("Unknown exception queueing sslyze command.\n%s" % utils.format_last_exception())
             data['errors'].append(text)
             logging.warning(text)
@@ -560,7 +560,7 @@ def scan_parallel(scanner, server_info, data, options):
                 data['errors'].append(error)
                 was_error = True
 
-        except Exception as err:
+        except Exception:
             was_error = True
             text = ("Exception inside async scanner result processing.\n%s" % utils.format_last_exception())
             data['errors'].append(text)


### PR DESCRIPTION
The latest version of pshtt simplifies the logic that determines if a domain supports HTTPS.  

Updating the version here isn't critical, since the new logic is functionally equivalent to the old, but it's good to stay current.