### PR TITLE
Use the latest version of trustymail

### DIFF
--- a/requirements-scanners.txt
+++ b/requirements-scanners.txt
@@ -5,7 +5,7 @@
 pshtt>=0.5.2
 
 # trustymail
-trustymail>=0.6.3
+trustymail>=0.6.4
 
 # sslyze
 sslyze>=2.0.1


### PR DESCRIPTION
The latest version of `trustymail` contains [a fix that stops the SPF record from being retrieved twice](https://github.com/dhs-ncats/trustymail/pull/97).  This is more efficient, and we were also seeing rare cases where the second DNS lookup of the SPF record was failing, so the latest version should be preferred.

The results returned by `trustymail` should be identical, except in cases where the second DNS lookup failed.