### PR TITLE
Bumped version of trustymail

### DIFF
--- a/requirements-scanners.txt
+++ b/requirements-scanners.txt
@@ -5,7 +5,7 @@
 pshtt>=0.5.2
 
 # trustymail
-trustymail>=0.6.4
+trustymail>=0.6.5
 
 # sslyze
 sslyze>=2.0.1


### PR DESCRIPTION
This incorporates the change in trustymail (https://github.com/dhs-ncats/trustymail/pull/99/commits/97d5f53ab3e90be38a9188b987844344d166f7b1) to treat `>= 2 URIs` "syntax error" as a "debug info" message.