### PR TITLE
Allow for Lambda retries and increase Lambda timeout

### DIFF
--- a/lambda/deploy
+++ b/lambda/deploy
@@ -70,7 +70,7 @@ if [ "$IS_CREATE" == "--create" ]; then
     --role $AWS_LAMBDA_ROLE \
     --handler lambda_handler.handler \
     --runtime python3.6 \
-    --timeout 300 \
+    --timeout 900 \
     --memory-size 128
 
 # Or, update the function's code with the latest zipped code.

--- a/scan
+++ b/scan
@@ -25,7 +25,7 @@ default_workers = 10
 global_max_workers = 1000
 
 # The default value to use for the maximum number of Lambda retries
-default_max_lambda_retries = 5
+default_max_lambda_retries = 0
 
 # Some metadata about the scan itself.
 start_time = scan_utils.local_now()
@@ -408,12 +408,15 @@ def perform_lambda_scan(scanner, domain, handles, environment, options, meta, pr
     invoke_client = options["_"]["lambda_options"]["invoke_client"]
     data = None
 
+    max_lambda_retries = options.get('lambda_retries',
+                                     default_max_lambda_retries)
+
     if 'lambda' not in meta:
         meta['lambda'] = {
             'retries': 0
         }
     else:
-        if meta['lambda']['retries'] < default_max_lambda_retries:
+        if meta['lambda']['retries'] < max_lambda_retries:
             meta['lambda']['retries'] = meta['lambda']['retries'] + 1
             logging.info('Attempting retry number {} for {}'.format(meta['lambda']['retries'], domain))
         else:

--- a/scan
+++ b/scan
@@ -24,6 +24,9 @@ from utils import FAST_CACHE_KEY, scan_utils
 default_workers = 10
 global_max_workers = 1000
 
+# The default value to use for the maximum number of Lambda retries
+default_max_lambda_retries = 5
+
 # Some metadata about the scan itself.
 start_time = scan_utils.local_now()
 start_command = str.join(" ", sys.argv)
@@ -397,7 +400,7 @@ def perform_local_scan(scanner, domain, handles, environment, options, meta):
 #
 # Catch some Lambda-specific exceptions around the invoke call,
 # but otherwise allow exceptions to bubble up to perform_scan.
-def perform_lambda_scan(scanner, domain, handles, environment, options, meta):
+def perform_lambda_scan(scanner, domain, handles, environment, options, meta, previousData=None):
     logging.warning("\tExecuting Lambda scan...")
 
     scanner_name = scanner.__name__.split(".")[-1]  # e.g. 'pshtt'
@@ -410,10 +413,12 @@ def perform_lambda_scan(scanner, domain, handles, environment, options, meta):
             'retries': 0
         }
     else:
-        if meta['lambda']['retries'] < 5:
+        if meta['lambda']['retries'] < default_max_lambda_retries:
             meta['lambda']['retries'] = meta['lambda']['retries'] + 1
+            logging.info('Attempting retry number {} for {}'.format(meta['lambda']['retries'], domain))
         else:
-            return None
+            logging.warn('No more retries for {}'.format(domain))
+            return previousData
 
     task_prefix = "task_"  # default, maybe make optional later
     task_name = "%s%s" % (task_prefix, scanner_name)
@@ -432,7 +437,7 @@ def perform_lambda_scan(scanner, domain, handles, environment, options, meta):
         # farming out the hard work to Lambda. This increases max workers
         # somewhat, since waiting on responses is much, much cheaper than
         # performing active scanning.
-
+        retry = False
         api_response = invoke_client.invoke(
             FunctionName=task_name,
             InvocationType='RequestResponse',
@@ -447,12 +452,11 @@ def perform_lambda_scan(scanner, domain, handles, environment, options, meta):
         raw = str(api_response['Payload'].read(), encoding='utf-8')
 
         response = json.loads(raw)
+        logging.debug('Response is: {}'.format(response))
 
         if response is None:
             meta['errors'].append("Response came back empty. Raw payload response:\n%s\nFull api_response:\n%s" % (raw, api_response))
-            # Retry
-            print('Kicking off retry number {}'.format(meta['lambda']['retries']))
-            return perform_lambda_scan(scanner, domain, handles, environment, options, meta)
+            retry = True
         # An errorMessage field implies a Lambda-level error.
         elif response.get("errorMessage") is None:
             # Payload has some per-task Lambda-specific info.
@@ -463,24 +467,26 @@ def perform_lambda_scan(scanner, domain, handles, environment, options, meta):
                 data = response['data']
             else:
                 meta['errors'].append("Response object lacked 'data' field. Raw response: %s" % raw)
+                retry = True
 
             # An error field implies an exception during the scan.
             if 'error' in response:
                 meta['errors'].append("Error or exception during scan: %s" % response['error'])
+                retry = True
 
         else:
             meta['errors'].append("Lambda error: %s" % raw)
-            # Retry
-            print('Kicking off retry number {}'.format(meta['lambda']['retries']))
-            return perform_lambda_scan(scanner, domain, handles, environment, options, meta)
+            retry = True
 
     except botocore.vendored.requests.exceptions.ReadTimeout:
         meta['errors'].append("Connection timeout while talking to Lambda.")
-        # Retry
-        print('Kicking off retry number {}'.format(meta['lambda']['retries']))
-        return perform_lambda_scan(scanner, domain, handles, environment, options, meta)
+        retry = True
 
-    return data
+    if not retry:
+        return data
+    else:
+        # Retry
+        return perform_lambda_scan(scanner, domain, handles, environment, options, meta, data)
 
 
 # Given just a CSV with some Lambda detail headers at the end,

--- a/scan
+++ b/scan
@@ -45,7 +45,7 @@ def set_aws_credentials(options):
         max_pool_connections=global_max_workers,
         connect_timeout=900,
         read_timeout=900,
-        retries={'max_attempts': 5}
+        retries={'max_attempts': 0}
     )
     invoke_client = lambda_session.client('lambda', config=invoke_config)
 
@@ -404,7 +404,16 @@ def perform_lambda_scan(scanner, domain, handles, environment, options, meta):
 
     invoke_client = options["_"]["lambda_options"]["invoke_client"]
     data = None
-    meta['lambda'] = {}
+
+    if 'lambda' not in meta:
+        meta['lambda'] = {
+            'retries': 0
+        }
+    else:
+        if meta['lambda']['retries'] < 5:
+            meta['lambda']['retries'] = meta['lambda']['retries'] + 1
+        else:
+            return None
 
     task_prefix = "task_"  # default, maybe make optional later
     task_name = "%s%s" % (task_prefix, scanner_name)
@@ -441,7 +450,9 @@ def perform_lambda_scan(scanner, domain, handles, environment, options, meta):
 
         if response is None:
             meta['errors'].append("Response came back empty. Raw payload response:\n%s\nFull api_response:\n%s" % (raw, api_response))
-
+            # Retry
+            print('Kicking off retry number {}'.format(meta['lambda']['retries']))
+            return perform_lambda_scan(scanner, domain, handles, environment, options, meta)
         # An errorMessage field implies a Lambda-level error.
         elif response.get("errorMessage") is None:
             # Payload has some per-task Lambda-specific info.
@@ -459,9 +470,15 @@ def perform_lambda_scan(scanner, domain, handles, environment, options, meta):
 
         else:
             meta['errors'].append("Lambda error: %s" % raw)
+            # Retry
+            print('Kicking off retry number {}'.format(meta['lambda']['retries']))
+            return perform_lambda_scan(scanner, domain, handles, environment, options, meta)
 
     except botocore.vendored.requests.exceptions.ReadTimeout:
         meta['errors'].append("Connection timeout while talking to Lambda.")
+        # Retry
+        print('Kicking off retry number {}'.format(meta['lambda']['retries']))
+        return perform_lambda_scan(scanner, domain, handles, environment, options, meta)
 
     return data
 

--- a/scan
+++ b/scan
@@ -43,9 +43,9 @@ def set_aws_credentials(options):
 
     invoke_config = botocore.config.Config(
         max_pool_connections=global_max_workers,
-        connect_timeout=300,
-        read_timeout=300,
-        retries={'max_attempts': 0}
+        connect_timeout=900,
+        read_timeout=900,
+        retries={'max_attempts': 5}
     )
     invoke_client = lambda_session.client('lambda', config=invoke_config)
 

--- a/utils/scan_utils.py
+++ b/utils/scan_utils.py
@@ -392,6 +392,10 @@ def build_scan_options_parser() -> ArgumentParser:
         "profile. Credentials/config for this named profile should already ",
         "be configured separately in the execution environment.",
     ]))
+    parser.add_argument("--lambda-retries", type=int, help="".join([
+        "The maximum number of times to retry a Lambda job that fails.  ",
+        "If not specified then the value 0 is used."
+    ]))
     parser.add_argument("--meta", action="store_true", help="".join([
         "Append some additional columns to each row with information about ",
         "the scan itself. This includes start/end times and durations, as ",


### PR DESCRIPTION
I find that when I perform the BOD scanning, there are usually a few Lambda jobs (out of approximately 200k) that I lose contact with.  The CloudWatch logs indicate that the Lambda job executed successfully, but the results do not make their way into the results CSV.  This pull request creates the option of rerunning failed jobs (up to some maximum number of times).

This pull request also increases the maximum run time of a Lambda function from 5 minutes to 15 minutes.  This should allow pathological scans that take an exceedingly long time to finish time to run.