### PR TITLE
Add dnspython

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,5 +9,8 @@
 # invocation.
 boto3
 
+# Used locally by trustymail code even when Lambda is used
+dnspython
+
 # Used in Lambda functions
 -r lambda/requirements-lambda.txt


### PR DESCRIPTION
Add `dnspython` to `requirements.txt`.  This python module is used locally when running `trustymail`, even when using Lambda.

This is a follow-up to #289.