### PR TITLE
Use latest trustymail

### DIFF
--- a/requirements-scanners.txt
+++ b/requirements-scanners.txt
@@ -5,7 +5,7 @@
 pshtt>=0.5.2
 
 # trustymail
-trustymail>=0.6.5
+trustymail>=0.6.6
 
 # sslyze
 sslyze>=2.0.1


### PR DESCRIPTION
The latest trustymail increases the verbosity for the SPF library that is used under the hood.  This information is occasionally useful when debugging BOD 18-01 SPF issues.