### PR TITLE
Do not hard code the DNS servers to use for the trustymail scanner

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,3 @@
-# Python CircleCI 2.0 configuration file
-
 version: 2
 jobs:
   build_36:

--- a/scanners/trustymail.py
+++ b/scanners/trustymail.py
@@ -38,10 +38,10 @@ def init_domain(domain, environment, options):
             int(port)
             for port in options.get('smtp_ports', default_smtp_ports).split(',')
         }
-        dns_hostnames = options.get('dns')
-        if dns_hostnames is not None:
-            dns_hostnames = dns_hostnames.split(',')
-        resolver = dns.resolver.Resolver(configure=dns_hostnames is None)
+        dns_hostnames = list_from_dict_key(options, 'dns')
+        resolver = dns.resolver.Resolver(configure=not dns_hostnames)
+        if dns_hostnames:
+            resolver.nameservers = dns_hostnames
         # This is a setting that controls whether we retry DNS servers
         # if we receive a SERVFAIL response from them.  We set this to
         # False because, unless the reason for the SERVFAIL is truly
@@ -60,8 +60,6 @@ def init_domain(domain, environment, options):
         # http://www.dnspython.org/docs/1.14.0/dns.resolver-pysrc.html#Resolver._compute_timeout.
         resolver.timeout = float(timeout)
         resolver.lifetime = float(timeout)
-        if dns_hostnames is not None:
-            resolver.nameservers = dns_hostnames
         # Use TCP, since we care about the content and correctness of
         # the records more than whether their records fit in a single
         # UDP packet.
@@ -128,9 +126,7 @@ def scan(domain, environment, options):
         int(port)
         for port in options.get('smtp_ports', default_smtp_ports).split(',')
     }
-    dns_hostnames = options.get('dns')
-    if dns_hostnames is not None:
-        dns_hostnames = dns_hostnames.split(',')
+    dns_hostnames = list_from_dict_key(options, 'dns')
 
     # --starttls implies --mx
     if options.get('starttls', False):

--- a/utils/scan_utils.py
+++ b/utils/scan_utils.py
@@ -504,8 +504,8 @@ def options() -> Tuple[dict, list]:
     opts = {k: v for k, v in vars(parsed).items() if v is not None}
 
     if opts.get("lambda_profile") and not opts.get("lambda"):
-            raise argparse.ArgumentTypeError(
-                "Can't set lambda profile unless lambda flag is set.")
+        raise argparse.ArgumentTypeError(
+            "Can't set lambda profile unless lambda flag is set.")
 
     # We know we want one value, but the ``nargs`` flag means we get a list.
     should_be_singles = (

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -230,8 +230,8 @@ def options_for_gather():
     services = [s.strip() for s in sys.argv[1].split(",")
                 if s not in set_services and s.strip()]
     if services and services[0].startswith("--"):
-            raise argparse.ArgumentTypeError(
-                "First argument must be a list of gatherers.")
+        raise argparse.ArgumentTypeError(
+            "First argument must be a list of gatherers.")
 
     parser = build_gather_options_parser(services)
     parsed, remaining = parser.parse_known_args()


### PR DESCRIPTION
These should be specified on the command line if needed.

I've tested this with the NCATS BOD 18-01 scanning and it works great for our purposes.  The reason I made this change is that we were running into a connection tracking limit in AWS, and using the AWS DNS instead of reaching out externally to Google reduces the problem considerably.