### PR TITLE
Add subdomain policy to trustymail output

### DIFF
--- a/requirements-scanners.txt
+++ b/requirements-scanners.txt
@@ -5,7 +5,7 @@
 pshtt>=0.5.2
 
 # trustymail
-trustymail>=0.6.6
+trustymail>=0.6.8
 
 # sslyze
 sslyze>=2.0.1

--- a/scanners/trustymail.py
+++ b/scanners/trustymail.py
@@ -311,7 +311,8 @@ headers = [
     "SPF Record", "Valid SPF", "SPF Results",
     "DMARC Record", "Valid DMARC", "DMARC Results",
     "DMARC Record on Base Domain", "Valid DMARC Record on Base Domain",
-    "DMARC Results on Base Domain", "DMARC Policy", "DMARC Policy Percentage",
+    "DMARC Results on Base Domain", "DMARC Policy", "DMARC Subdomain Policy",
+    "DMARC Policy Percentage",
     "DMARC Aggregate Report URIs", "DMARC Forensic Report URIs",
     "DMARC Has Aggregate Report URI", "DMARC Has Forensic Report URI",
     "Syntax Errors", "Debug Info"


### PR DESCRIPTION
We (NCATS) want to do something with the DMARC subdomain policy in the reporting stage.  As a result we need this data to be output by domain-scan.