### PR TITLE
Update to use the latest version of pshtt

### DIFF
--- a/requirements-scanners.txt
+++ b/requirements-scanners.txt
@@ -2,7 +2,7 @@
 # Requirements used by specific scanners.
 
 # pshtt
-pshtt>=0.5.2
+pshtt>=0.5.4
 
 # trustymail
 trustymail>=0.6.8


### PR DESCRIPTION
The latest version of pshtt only contains cosmetic changes due to the renaming of the dhs-ncats GitHub organization to cisagov, but we may as well be current.