### PR TITLE
Update to use the latest trustymail

### DIFF
--- a/requirements-scanners.txt
+++ b/requirements-scanners.txt
@@ -5,7 +5,7 @@
 pshtt>=0.5.2
 
 # trustymail
-trustymail>=0.6.8
+trustymail>=0.6.9
 
 # sslyze
 sslyze>=2.0.1


### PR DESCRIPTION
The latest trustymail contains a small fix that allows DMARC records with a `pct` tag equal to zero. 
(Previously a value of zero was disallowed.)  This is in accordance with [RFC7489](https://tools.ietf.org/html/rfc7489#section-6.3).