### PR TITLE
Update to use the latest sslyze, pshtt, and trustymail

### DIFF
--- a/requirements-scanners.txt
+++ b/requirements-scanners.txt
@@ -2,13 +2,13 @@
 # Requirements used by specific scanners.
 
 # pshtt
-pshtt>=0.6.1
+pshtt>=0.6.2
 
 # trustymail
-trustymail>=0.7.0
+trustymail>=0.7.1
 
 # sslyze
-sslyze>=2.0.1
+sslyze>=2.0.6
 
 # a11y / csp
 pyyaml


### PR DESCRIPTION
* The latest sslyze has some minor bugfixes.
* pshtt has sslyze as a requirement, and the latest pshtt requires that the latest version of sslyze be installed.
* The latest trustymail contains a bugfix for handling SPF records that use the `include` directive.  In the past these records could have been evaluated incorrectly.  More details at cisagov/trustymail#111.