### PR TITLE
Update to use the latest trustymail

### DIFF
--- a/requirements-scanners.txt
+++ b/requirements-scanners.txt
@@ -5,7 +5,7 @@
 pshtt>=0.6.2
 
 # trustymail
-trustymail>=0.7.1
+trustymail>=0.7.2
 
 # sslyze
 sslyze>=2.0.6

--- a/requirements-scanners.txt
+++ b/requirements-scanners.txt
@@ -5,7 +5,7 @@
 pshtt>=0.6.2
 
 # trustymail
-trustymail>=0.7.2
+trustymail>=0.7.3
 
 # sslyze
 sslyze>=2.0.6


### PR DESCRIPTION
The latest trustymail prints out the text sent and received during the SMTP exchange.  This is very useful for debugging.  See cisagov/trustymail#114 for more details.

It also forces smtplib to use IPv4 addresses for mail servers.  The IPv6 addresses cause problems when running in AWS Lambda, at least inside a VPC.  See cisagov/trustymail#115 for more details.