### PR TITLE
Update to use the latest version of trustymail

### DIFF
--- a/requirements-scanners.txt
+++ b/requirements-scanners.txt
@@ -5,7 +5,7 @@
 pshtt>=0.6.2
 
 # trustymail
-trustymail>=0.7.3
+trustymail>=0.7.4
 
 # sslyze
 sslyze>=2.0.6


### PR DESCRIPTION
The latest version of trustymail outputs a warning if the `sp` tag is explicitly set for a subdomain's DMARC record.  See cisagov/trustymail#116 for more details.