### PR TITLE
Update to use the latest version of trustymail

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # VERSION 0.3.0
 
 FROM ubuntu:16.04
-MAINTAINER Shane Frasier <jeremy.frasier@beta.dhs.gov>
+MAINTAINER Shane Frasier <jeremy.frasier@trio.dhs.gov>
 
 ###
 # Dependencies

--- a/requirements-scanners.txt
+++ b/requirements-scanners.txt
@@ -5,7 +5,7 @@
 pshtt>=0.6.2
 
 # trustymail
-trustymail>=0.7.4
+trustymail>=0.7.5
 
 # sslyze
 sslyze>=2.0.6


### PR DESCRIPTION
The latest version of trustymail more gracefully handles mail servers that only support IPv6.  See cisagov/trustymail#117 for more details.