### PR TITLE
Update to use the latest version of pshtt

### DIFF
--- a/requirements-scanners.txt
+++ b/requirements-scanners.txt
@@ -2,7 +2,7 @@
 # Requirements used by specific scanners.
 
 # pshtt
-pshtt>=0.6.2
+pshtt>=0.6.3
 
 # trustymail
 trustymail>=0.7.4


### PR DESCRIPTION
The latest version of pshtt tightens up the logic in the `is_domain_supports_https()` method. See cisagov/pshtt#192 for details.