### PR TITLE
Update to use the latest pshtt

### DIFF
--- a/requirements-scanners.txt
+++ b/requirements-scanners.txt
@@ -2,7 +2,7 @@
 # Requirements used by specific scanners.
 
 # pshtt
-pshtt>=0.6.4
+pshtt>=0.6.5
 
 # trustymail
 trustymail>=0.7.5


### PR DESCRIPTION
This is necessary because pshtt was pulling in a new version of sslyze that contains breaking changes.  As a result, pshtt was modified in cisagov/pshtt#200 to pin the version of sslyze to 2.0.6.  This is a temporary measure until cisagov/pshtt#199 can be tested, approved, and merged.