### PR TITLE
Pin sslyze version to 2.x, and note Python compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ There is also built-in support for using **headless Chrome** to efficiently meas
 
 ### Requirements
 
-`domain-scan` requires **Python 3.6 and up**.
+`domain-scan` requires **Python 3.6 or 3.7**.
 
 To install **core dependencies**:
 

--- a/requirements-scanners.txt
+++ b/requirements-scanners.txt
@@ -8,7 +8,7 @@ pshtt>=0.6.6
 trustymail>=0.7.5
 
 # sslyze
-sslyze>=2.1.3
+sslyze>=2.1.3,<3.0.0
 
 # a11y / csp
 pyyaml


### PR DESCRIPTION
`sslyze` is currently pinned to `> 2.1.3`, which lead to a recently released `3.0` version being installed. This version currently has an incompatibility with `domain-scan`.

Additionally, `sslyze 2.1.x` is incompatible with Python 3.8. https://github.com/nabla-c0d3/sslyze/issues/408

So this PR notes the incompatibility and pins us to `sslyze 2.x`. I'll add an issue to follow-up on making the scanner compatible with `3.x`.